### PR TITLE
Performance fixes for parser and user expressions list page

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"install": "^0.13.0",
 		"javascript-time-ago": "^2.5.9",
 		"rain-metadata": "https://github.com/beehive-innovation/rain-metadata#4d0c04314d9ee96468c3464216f8e287944aa383",
-		"rain-svelte-components": "https://github.com/beehive-innovation/rain-svelte-components#b0c03a5667a011bf0d2f67fef239cc1f987d79c7",
+		"rain-svelte-components": "https://github.com/beehive-innovation/rain-svelte-components#8a1102a295393b0b7331e2175c58fd1ee78b23db",
 		"supabase": "^1.15.0",
 		"svelte-ethers-store": "^2.5.8",
 		"tailwind-gradient-mask-image": "^1.0.0",

--- a/src/lib/utils/everyAfter.ts
+++ b/src/lib/utils/everyAfter.ts
@@ -1,0 +1,13 @@
+export function everyAfter(fn: any) {
+    let called: boolean, value: any;
+
+    return function wrap(...args) {
+        if (!called) {
+            called = true;
+            return;
+        }
+        value = fn.apply(this, args);
+        // fn = undefined;
+        return value;
+    };
+}

--- a/src/routes/search/[addressOrText]/+page.server.ts
+++ b/src/routes/search/[addressOrText]/+page.server.ts
@@ -13,7 +13,6 @@ export const load: PageServerLoad = async (event) => {
 	});
 
 	const { success, result } = await resp.json();
-	console.log(result);
 
 	if (success) {
 		const typenameDB = result.resultDB?.type;

--- a/src/routes/user/[user]/expressions/+page.server.ts
+++ b/src/routes/user/[user]/expressions/+page.server.ts
@@ -39,7 +39,6 @@ export const load: PageServerLoad = async (event) => {
 	const tagResp = await supabaseClient.rpc('get_unique_tags_for_user')
 	if (tagResp.error) throw error(404, 'Not found');
 	const tags = tagResp.data[0].tags.slice(1, -1).split(',')
-	console.log('resp', tags);
 
 	let draft_expressions;
 	if (resp.ok) ({ draft_expressions } = await resp.json());

--- a/src/routes/user/[user]/expressions/+server.ts
+++ b/src/routes/user/[user]/expressions/+server.ts
@@ -10,16 +10,6 @@ export const POST: RequestHandler = async (event) => {
 		.from('draft_expressions')
 		.select('*, contract ( metadata, project (name, logo_url), id ), interpreter ( metadata, id )');
 
-	if (selectedContract && selectedContract !== 'all' && selectedContract !== 'no-contract')
-		query = query.eq('contract', selectedContract);
-	if (selectedContract === 'no-contract') query = query.is('contract', null);
-	if (selectedInterpreter) query = query.eq('interpreter', selectedInterpreter);
-	if (searchValue)
-		query = query.textSearch('name', searchValue, {
-			type: 'websearch',
-			config: 'english'
-		});
-
 	if (selectedContract && selectedContract !== 'all' && selectedContract !== 'no-contract') query = query.eq('contract', selectedContract)
 	if (selectedContract === 'no-contract') query = query.is('contract', null)
 	if (selectedInterpreter) query = query.eq('interpreter', selectedInterpreter)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3592,6 +3592,7 @@ minipass@^3.0.0:
   dependencies:
     yallist "^4.0.0"
 
+
 minipass@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.0.0.tgz#7cebb0f9fa7d56f0c5b17853cbe28838a8dbbd3b"
@@ -4067,9 +4068,9 @@ quick-lru@^5.1.1:
     ethers "^5.5.2"
     prettier "^2.6.2"
 
-"rain-svelte-components@https://github.com/beehive-innovation/rain-svelte-components#b0c03a5667a011bf0d2f67fef239cc1f987d79c7":
+"rain-svelte-components@https://github.com/beehive-innovation/rain-svelte-components#8a1102a295393b0b7331e2175c58fd1ee78b23db":
   version "0.0.1"
-  resolved "https://github.com/beehive-innovation/rain-svelte-components#b0c03a5667a011bf0d2f67fef239cc1f987d79c7"
+  resolved "https://github.com/beehive-innovation/rain-svelte-components#8a1102a295393b0b7331e2175c58fd1ee78b23db"
   dependencies:
     "@beehiveinnovation/rainlang" "https://github.com/beehive-innovation/rainlang#e17dc1d8a0b19c43be59907f6b02bccd51acf707"
     "@formkit/auto-animate" "^1.0.0-beta.3"


### PR DESCRIPTION
There was three issues with this:

- In the Editable component (from rain-svelte-components), where `tree = Parser.getParseTree(text, rainterpreterOpmeta)` (from rainlang) was being called for every text Node. I fixed this by caching the tree for the same text value (with a cache depth of one). This stops multiple parses of the same text.
- Layout glitches on the list of expressions on the user's expressions page. I removed autoAnimate for now, and it seems overall better.
- `getDraftExpressions` was being called immediately on render, because the reactive line was triggering as the different sorts/filters were set with initial values. I fixed this by wrapping `getDraftExpressions` with an `everyAfter` function, so it won't actually be called the first time it's run.