### PR TITLE
Remove Placeholders section

### DIFF
--- a/src/docs/20-simple-expressions/20-anatomy-of-an-expression.svelte.md
+++ b/src/docs/20-simple-expressions/20-anatomy-of-an-expression.svelte.md
@@ -60,14 +60,6 @@ For example, the following program calculates the sum of 1 and 5, then multiplie
 <Formatter raw={`myCalculation: add(1 5),
 result: mul(myCalculation 2);`} />
 
-## Using placeholders on the left-hand side
-
-You can also use placeholders on the left-hand side of an expression instead of naming the outputs produced by the right-hand side of the expression. For example, the following expression calculates the sum of 1 and 2 and multiplies that result by 3:
-
-<Formatter raw={`_: mul(add(1 2) 3)`} />
-
-As you can see, using placeholders on the left-hand side of an expression allows you to perform calculations without naming the outputs.
-
 ## Comments
 
 You can use comments for adding notes or explanations to your code.


### PR DESCRIPTION
 this whole section seems redundant because it was already mentioned that the `_` is used for non-named Outputs (unless you have this section here to doubly highlight that point)