### PR TITLE
97 hook up fork button on formatter and save button on parser in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"javascript-time-ago": "^2.5.9",
 		"jsonwebtoken": "^8.5.1",
 		"rain-metadata": "https://github.com/rainprotocol/rain-metadata#4d0c04314d9ee96468c3464216f8e287944aa383",
-		"rain-svelte-components": "https://github.com/rainprotocol/rain-svelte-components#44320c53b8d6d6091461474292440a2dfdb5a64b",
+		"rain-svelte-components": "https://github.com/rainprotocol/rain-svelte-components#d8e8378c0f825b250941d138fc19be49870ef87f",
 		"supabase": "^1.15.0",
 		"svelte-ethers-store": "^2.5.8",
 		"svelte-splitpanes": "^0.7.10",

--- a/src/docs/10-introduction/30-breaking-down-an-expression.svelte.md
+++ b/src/docs/10-introduction/30-breaking-down-an-expression.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -12,7 +12,7 @@ published: true
 
 Consider this simple Rainlang expression:
 
-<Formatter raw={`_: add(1 2);`} />
+<ForkableFormatter raw={`_: add(1 2);`} />
 
 The expression starts with an underscore, which is a placeholder for the output of the expression. In this case, the output will be the result of the addition of 1 and 2.
 

--- a/src/docs/10-introduction/30-breaking-down-an-expression.svelte.md
+++ b/src/docs/10-introduction/30-breaking-down-an-expression.svelte.md
@@ -29,7 +29,7 @@ A smart contract could use this result to, for example, decide how many of a tok
 
 Try changing the numbers that are being added in this expression and see how the simulated result changes.
 
-<Parser raw={`_: add(1 2);`}/>
+<Parser raw={`_: add(1 2);`} hideSave hideLoad hideExpand hideHelp/>
 
 ## Terms
 

--- a/src/docs/20-simple-expressions/20-anatomy-of-an-expression.svelte.md
+++ b/src/docs/20-simple-expressions/20-anatomy-of-an-expression.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -16,7 +16,7 @@ In Rainlang, **Expressions** are written using a specific syntax that consists o
 
 The syntax for an expression in Rainlang is as follows:
 
-<Formatter raw={`output: word(input1 input2 ... inputN)`} />
+<ForkableFormatter raw={`output: word(input1 input2 ... inputN)`} />
 
 In this syntax, the "output" is the name of the result of the expression, the "word" is the name of the word that is being executed, and the "input1 input2 ... inputN" are the values or expressions that are passed to the function as inputs.
 
@@ -33,13 +33,13 @@ In Rainlang, there are many different Words that can be used in expressions. Som
 
 These Words can be used in expressions to perform a wide range of calculations. For example, the following expression calculates the sum of 1 and 2 and names the result "mySum":
 
-<Formatter raw={`mySum: add(1 2)`} />
+<ForkableFormatter raw={`mySum: add(1 2)`} />
 
 We’ll explore more words and their uses throughout these guides.
 Inputs
 The inputs to a Word can be either numeric values or the results of other expressions. For example, the following expression calculates the product of the sum of 1 and 2 and the difference of 3 and 4 and names the result '\_'. '\_' is used as a placeholder when you don’t want to name the output (see below).
 
-<Formatter raw={`_: mul(add(1 2) sub(4 3))`} />
+<ForkableFormatter raw={`_: mul(add(1 2) sub(4 3))`} />
 
 In this expression, the add word is used as an input to the mul word. This is an example of a nested expression, where one expression is used as an input to another expression.
 
@@ -47,7 +47,7 @@ In this expression, the add word is used as an input to the mul word. This is an
 
 The output of an expression is a named value that can be used in other expressions or as an input to a smart contract. For example, the following expression calculates the sum of 1 and 2 and names the result "mySum":
 
-<Formatter raw={`mySum: add(1 2)`} />
+<ForkableFormatter raw={`mySum: add(1 2)`} />
 
 In this expression, the "mySum" value is the output of the add word, and because it’s named it can be used in other lines. If it’s the last line, it will be passed to the host smart contract as an input.
 
@@ -57,14 +57,14 @@ Now that you know how to make a simple calculation and name its output, you can 
 
 For example, the following program calculates the sum of 1 and 5, then multiplies that result by 2 and names the output "result":
 
-<Formatter raw={`myCalculation: add(1 5),
+<ForkableFormatter raw={`myCalculation: add(1 5),
 result: mul(myCalculation 2);`} />
 
 ## Comments
 
 You can use comments for adding notes or explanations to your code.
 
-<Formatter raw={`\/\*
+<ForkableFormatter raw={`\/\*
 This is a comment block. In Rainlang, comments start with a slash and an asterisk and end with an asterisk and a slash
 */`} />
 

--- a/src/docs/20-simple-expressions/30-understanding-the-stack.svelte.md
+++ b/src/docs/20-simple-expressions/30-understanding-the-stack.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -22,7 +22,7 @@ This allows users to perform computations on-chain and use the results to accomp
 
 To understand how the stack works in Rainlang, let's start with a simple expression that calculates the sum of 1 and 2 and names the output "myCalculation":
 
-<Formatter raw={`myCalculation: add(1 2)`} />
+<ForkableFormatter raw={`myCalculation: add(1 2)`} />
 
 This expression has two inputs, 1 and 2, and one output, the result of adding 1 and 2 (i.e. 3). When this expression is executed, the interpreter takes the inputs from the stack, performs the calculation, and puts the result back into the stack. In this case, the stack will look like this after the expression is executed:
 
@@ -37,7 +37,7 @@ As you can see, the stack contains one item, the result of the calculation.
 
 In Rainlang, you can nest expressions within other expressions. For example, the following expression calculates the sum of 1 and 2, then multiplies that result by 3 and names the output "result":
 
-<Formatter raw={`result: mul(add(1 2) 3)`} />
+<ForkableFormatter raw={`result: mul(add(1 2) 3)`} />
 
 This expression has two nested expressions, the first of which calculates the sum of 1 and 2, and the second of which multiplies that result by 3. When this expression is executed, the interpreter evaluates the nested expressions in order, starting with the innermost expression. In this case, the stack will look like this after the innermost expression (i.e. add(1 2)) is executed:
 

--- a/src/docs/20-simple-expressions/40-rain-words.svelte.md
+++ b/src/docs/20-simple-expressions/40-rain-words.svelte.md
@@ -3,11 +3,6 @@ title: Rain words
 published: true
 ---
 
-<script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
-	import { Parser } from 'rain-svelte-components/package'
-</script>
-
 In Rainlang, Words are the fundamental building blocks of Rainlang expressions. A "Word" is a unit of logic that performs a specific operation or function, similar to opcodes or instructions in other programming languages. Words are combined together to form Expressions, which are used to perform calculations or execute specific tasks.
 
 ## Categories of Words

--- a/src/docs/20-simple-expressions/50-delimiting-lines.svelte.md
+++ b/src/docs/20-simple-expressions/50-delimiting-lines.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -19,7 +19,7 @@ In Rainlang, each line of code must be delimited with a comma, and each source i
 
 For example, the following program calculates the sum of 1 and 2 and names the output "myCalculation", then multiplies that result by 3 and names the output "result":
 
-<Formatter raw={`myCalculation: add(1 2),
+<ForkableFormatter raw={`myCalculation: add(1 2),
 result: mul(myCalculation 3);`} />
 
 Notice that each line of code is followed by a comma, except for the last line, which must be followed by a semicolon. This is the correct way to delimit lines in Rainlang.
@@ -28,21 +28,21 @@ An expression can have multiple sources, which are sub-expressions delimited by 
 
 Here is an example of an expression with multiple sources. The following expression has two sources.
 
-<Formatter raw={`myCalculation: add(1 2);
+<ForkableFormatter raw={`myCalculation: add(1 2);
 myCalculation: mul(1 2);`} />
 
 In this example, the first source calculates the sum of 1 and 2 and names the output "myCalculation". The second source multiplies them together, and also names the output “myCalculation”. You can do this because named outputs are not shared between sources. Notice that each source is followed by a semicolon, except for the last source.
 
 If an expression has only one source, then there must be a semicolon at the end of the line. For example, the following expression has only one source and therefore requires a semicolon at the end:
 
-<Formatter raw={`myCalculation: add(1 2);`} />
+<ForkableFormatter raw={`myCalculation: add(1 2);`} />
 
 If you forget to include the comma or semicolon at the end of a line, you will get a syntax error when you try to run your program. For example, the following expression has only one source but is missing the semicolon at the end, so it will produce a syntax error:
 
-<Formatter raw={`myCalculation: add(1 2)`} />
+<ForkableFormatter raw={`myCalculation: add(1 2)`} />
 
 To fix this error, simply add a semicolon at the end of the line, like this:
 
-<Formatter raw={`myCalculation: add(1 2);`} />
+<ForkableFormatter raw={`myCalculation: add(1 2);`} />
 
 In summary, it is important to remember to delimit each line of code with a comma and each source with a semicolon.

--- a/src/docs/20-simple-expressions/60-getting-token-balances.svelte.md
+++ b/src/docs/20-simple-expressions/60-getting-token-balances.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -17,7 +17,7 @@ Use this box to experiment with ideas below
 
 In Rainlang, you can use the erc20balanceof word to get the balance of an ERC20 token for a specific Ethereum wallet. The erc20balanceof word takes two parameters: the address of the ERC20 token contract, and the address of the Ethereum wallet. For example, the following expression gets the balance of an ERC20 token with contract address 0x123456 for an Ethereum wallet with address 0xabcdef and names the output "myBalance":
 
-<Formatter raw={`myBalance: erc20balanceof(0x123456 0xabcdef)`} />
+<ForkableFormatter raw={`myBalance: erc20balanceof(0x123456 0xabcdef)`} />
 
 This expression will return the balance of the ERC20 token for the specified wallet and put the result on the top of the stack. For example, if the balance is 100, the stack will look like this after the expression is executed:
 
@@ -27,7 +27,7 @@ This expression will return the balance of the ERC20 token for the specified wal
 
 You can then use the named output, "myBalance", in subsequent expressions to perform calculations with the balance. For example, the following expression calculates the result of adding 10 to the balance of the ERC20 token and names the output "result":
 
-<Formatter raw={`myBalance: erc20balanceof(0x123456 0xabcdef),
+<ForkableFormatter raw={`myBalance: erc20balanceof(0x123456 0xabcdef),
 result: add(myBalance 10)`} />
 
 This expression will take the value of "myBalance" from the stack, add 10 to it, and put the result back into the stack. In this case, if the balance of the ERC20 token is 100, the stack will look like this after the expression is executed:

--- a/src/docs/20-simple-expressions/70-using-the-if-word.svelte.md
+++ b/src/docs/20-simple-expressions/70-using-the-if-word.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -17,7 +17,7 @@ Use this box to experiment with ideas below
 
 In Rainlang, you can use the if word to perform different actions based on a given condition. The if word takes three parameters: a condition, a value to return if the condition is true, and a value to return if the condition is false. For example, the following expression gets the balance of an ERC20 token with contract address 0x123456 for an Ethereum wallet with address 0xabcdef and returns a value of 10 if the balance is greater than 10, and a value of 5 if the balance is 10 or less:
 
-<Formatter raw={`myBalance: erc20balanceof(0x123456 0xabcdef),
+<ForkableFormatter raw={`myBalance: erc20balanceof(0x123456 0xabcdef),
 high: 10,
 low: 5,
 result: if(greater-than(myBalance 10) high low);`} />

--- a/src/docs/20-simple-expressions/80-using-logic-words.svelte.md
+++ b/src/docs/20-simple-expressions/80-using-logic-words.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -23,25 +23,25 @@ The "any" word takes any number of parameters and returns true if any of the par
 
 To understand how to use these words, let's start with a simple example. The following expression uses the "if" word to check if the number 3 is greater than 10, and names the output "result":
 
-<Formatter raw={`result: if(greater-than(3 10) 1 0)`} />
+<ForkableFormatter raw={`result: if(greater-than(3 10) 1 0)`} />
 
 In this case, the "if" word will evaluate the condition "greater-than(3 10)". Since 3 is not greater than 10, the "if" word will return 0, which is the value specified for the "false" case. The output of the expression is named "result".
 
 In a more complicated example, the following "if" statement uses the "every" word to evaluate multiple conditions and names the output "result":
 
-<Formatter raw={`result: if(every(greater-than(a b) less-than(c d)) 1 0)`} />
+<ForkableFormatter raw={`result: if(every(greater-than(a b) less-than(c d)) 1 0)`} />
 
 In this case, the "if" statement will return 1 if the condition "greater-than(a b)" and the condition "less-than(c d)" are both true, and 0 otherwise. The output of the "if" statement is named "result".
 
 Similarly, the following "if" statement uses the "any" word to evaluate multiple conditions and names the output "result".
 
-<Formatter raw={`result: if(any(equal_to(a b) equal_to(c d)) 1 0)`} />
+<ForkableFormatter raw={`result: if(any(equal_to(a b) equal_to(c d)) 1 0)`} />
 
 In this case, the "if" statement will return 1 if either the condition "equals(a b)" or the condition "equals(c d)" is true, and 0 otherwise. The output of the "if" statement is named "result".
 
 In addition to the "every" and "any" words, Rainlang also includes the "greater-than" and "less-than" words, which can be used to compare two numbers and return true or false based on the comparison. For example, the following "if" statement uses the "greater-than" word to evaluate a condition and names the output "result":
 
-<Formatter raw={`result: if(greater-than(a b) 1 0)`} />
+<ForkableFormatter raw={`result: if(greater-than(a b) 1 0)`} />
 
 In this case, the "if" statement will return 1 if the value of "a" is greater than the value of "b", and 0 otherwise. The output of the "if" statement is named "result".
 
@@ -49,13 +49,13 @@ Here’s another example that uses another available word ‘erc20balanceof’. 
 
 For example, the following expression uses the "erc20balanceof" word to check the balance of a token with the address "0x123" for the wallet with the address "0x456", and names the output "balance":
 
-<Formatter raw={`balance: erc20balanceof(0x123 0x456)`} />
+<ForkableFormatter raw={`balance: erc20balanceof(0x123 0x456)`} />
 
 In this case, the "erc20balanceof" word will put the balance of the token with the address "0x123" for the wallet with the address "0x456" on the top of the stack. The output of the expression is named "balance".
 
 You can use the "erc20balanceof" word in combination with the "every" and "any" words to evaluate multiple conditions in an "if" statement. For example, the following "if" statement uses the "every" word and the "erc20balanceof" word to evaluate multiple conditions and names the output "result":
 
-<Formatter raw={`balance1condition: greater-than(erc20balanceof(0x789 0xabc) 10),
+<ForkableFormatter raw={`balance1condition: greater-than(erc20balanceof(0x789 0xabc) 10),
 balance2condition: greater-than(erc20balanceof(0x123 0x456) 10),
 bothConditions: every(balance1condition balance2condition),
 result: if(bothConditions 1 0)`} />

--- a/src/docs/30-intermediate-expressions/10-using-context.svelte.md
+++ b/src/docs/30-intermediate-expressions/10-using-context.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 
 	const expression1 = `toAddress: context\<0 1>()`
@@ -27,15 +27,15 @@ Different smart contracts will insert different data into the context grid, so t
 
 To use the context word in a Rainlang expression, you can simply use the coordinates of the cell you want to access as the operand of the word, followed by a set of parentheses. The result of the expression can be named on the left-hand side of the statement. For example, to access the "to" address in a "can transfer" expression and name the result "toAddress", you could use the context word with the coordinates 0 1, like this:
 
-<Formatter raw={expression1} />
+<ForkableFormatter raw={expression1} />
 
 This expression would return the "to" address as a string and name the result "toAddress". You can then use this named output in subsequent calculations or comparisons. For example, to check if the "to" address is the same as a specific address, you could use the equals function, like this:
 
-<Formatter raw={expression2} />
+<ForkableFormatter raw={expression2} />
 
 In this expression, the equals function compares the value of toAddress to the string "some-address" and returns 1 if they are equal and 0 if they are not. You can then use this result in an if statement to control the flow of your program. For example, to block a transfer if the "to" address is "some-address", you could use the following expression:
 
-<Formatter raw={expression3} />
+<ForkableFormatter raw={expression3} />
 
 This expression checks if the "to" address is "some-address" using the equals function, and if it is, it returns 0, which will block the transfer.
 

--- a/src/docs/30-intermediate-expressions/20-understanding-set-and-get.svelte.md
+++ b/src/docs/30-intermediate-expressions/20-understanding-set-and-get.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 </script>
 
@@ -22,33 +22,33 @@ For example, you might use "set" and "get" to keep track of the total number of 
 
 The "set" word has the syntax "set(key value)", where "key" is a unique identifier for the value and "value" is the value you want to store. For example, the following expression uses the "set" word to store the number 10 under the key "myValue":
 
-<Formatter raw={`:set(myValue 10)`} />
+<ForkableFormatter raw={`:set(myValue 10)`} />
 
 Notice that the line starts with a colon (:). This is required for all lines in Rainlang, even those that do not produce an output. In this case, since the "set" word does not produce an output, you must still start the line with a colon.
 
 The "get" word has the syntax "get(key)", where "key" is the unique identifier for the value you want to retrieve. For example, the following expression uses the "get" word to retrieve the value stored under the key "myValue":
 
-<Formatter raw={`result: get(myValue)`} />
+<ForkableFormatter raw={`result: get(myValue)`} />
 
 To use the "set" and "get" words in an expression, you can combine them with other Rainlang words and operations. For example, the following expression calculates the sum of 1 and 5 and stores the result under the key "myValue":
 
-<Formatter raw={`:set(myValue add(1 5))`} />
+<ForkableFormatter raw={`:set(myValue add(1 5))`} />
 
 You can also use the "get" word to retrieve the stored value and use it in subsequent calculations. For example, the following expression retrieves the value stored under the key "myValue" and multiplies it by 2:
 
-<Formatter raw={`result: mul(get(myValue) 2)`} />
+<ForkableFormatter raw={`result: mul(get(myValue) 2)`} />
 
 In this case, the "get" word will retrieve the value stored under the key "myValue" (i.e. 6), and the "mul" word will multiply it by 2 to produce the final output of 12.
 
 To accumulate values over time, you can use the "set" and "get" words in combination with other Rainlang words and operations. For example, the following expression uses the "add" word to increment the value stored under the key "myValue" by 1.
 
-<Formatter raw={`:set(myValue add(get(myValue) 1))`} />
+<ForkableFormatter raw={`:set(myValue add(get(myValue) 1))`} />
 
 In this case, the "get" word retrieves the value stored under the key "myValue" (i.e. 6), the "add" word adds 1 to that value (i.e. 7), and the "set" word stores the result (i.e. 7) under the key "myValue" for future use.
 
 You can also use logic words like "if" to control the flow of your program based on the values stored in the interpreter. For example, the following expression uses the "if" word to check if the value stored under the key "myValue" is greater than 10, and names the output "result":
 
-<Formatter raw={`result: if(greater-than(get(myValue) 10) 1 0)`} />
+<ForkableFormatter raw={`result: if(greater-than(get(myValue) 10) 1 0)`} />
 
 In this case, the "if" word will evaluate the condition "greater-than(get(myValue) 10)" using the value stored under the key "myValue" (i.e. 7). Since the value is not greater than 10, the "if" word will return 0, which is the value specified for the "false" case. The output of the expression is named "result".
 

--- a/src/docs/30-intermediate-expressions/30-accumulating-with-set-and-get.svelte.md
+++ b/src/docs/30-intermediate-expressions/30-accumulating-with-set-and-get.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 
 	const expression = `/* Calculate the amount of the token to mint */
@@ -45,7 +45,7 @@ new-accumulated-amount: add(amount-so-far amount-for-this-mint),
 
 Example: To use the "if" word to check if the accumulated amount of a token for a wallet is above a certain value, you can use the following expression:
 
-<Formatter raw={expression} />
+<ForkableFormatter raw={expression} />
 
 In this expression, the "amount" variable is set to a constant value of 1000. Then, the "result" variable is calculated using the "if" word to check if the accumulated amount is above 20000 using the "greater-than" word and the value stored under the key "sender()". If the accumulated amount is above 20000, the "if" word returns 0, which means that no tokens will be minted. Otherwise, the "if" word returns the "amount" variable, which is the amount of tokens to mint.
 

--- a/src/docs/40-writing-for-orderbook/10-basic-orders.svelte.md
+++ b/src/docs/40-writing-for-orderbook/10-basic-orders.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 
 	const expression = `amount: 1000,
@@ -34,7 +34,7 @@ The amount value is known as the 'maxAmount' and will be used by the Orderbook c
 
 Use the 'maxAmount' and 'price' values to construct your order expression. For example, to place a bid to buy 100 TKN at a maximum price of 1 USDT per TKN, you could use the following expression:
 
-<Formatter raw={`amount: 100,
+<ForkableFormatter raw={`amount: 100,
 the-price: 1,
 _ _: amount the-price`} />
 
@@ -50,7 +50,7 @@ When your Order is cleared by Orderbook, it is matched to another Order submitte
 
 To write an order expression using the 'set' and 'get' words to only clear a maximum of 1000 tokens for a specific counterparty at a price of 1, you can use the following expression:
 
-<Formatter raw={`amount: 100,
+<ForkableFormatter raw={`amount: 100,
 the-price: 1,
 _ _: amount the-price`} />
 

--- a/src/docs/40-writing-for-orderbook/20-dca-strategy.svelte.md
+++ b/src/docs/40-writing-for-orderbook/20-dca-strategy.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 
 	const expression = `/* Calculate the number of seconds in a month */
@@ -57,43 +57,43 @@ storage-key: hash(order-author order-hash),`
 A dollar-cost averaging (DCA) strategy is a common investment technique used to mitigate the risks of volatility in the market by buying a fixed amount of a particular asset at regular intervals. This can be useful for traders who want to buy a specific token over time, without having to worry about the market fluctuations.
 To implement a DCA order strategy in Rainlang, you can use the following expression:
 
-<Formatter raw={expression} />
+<ForkableFormatter raw={expression} />
 
 Let's break down this expression line by line to understand how it works:
 
-<Formatter raw={`seconds-in-month: mul(60 60 24 30),
+<ForkableFormatter raw={`seconds-in-month: mul(60 60 24 30),
 dollars-per-month: 1000,
 dollars-per-second: div(1000 seconds-in-month),`} />
 
 The first part of the expression calculates the number of seconds in a month using the mul word to multiply the number of minutes in an hour by the number of hours in a day by the number of days in a month. This is then used to calculate the maximum amount of tokens that can be sent per second using the div word to divide the maximum amount per month by the number of seconds in a month.
 
-<Formatter raw={`start-timestamp: 1668780839,`} />
+<ForkableFormatter raw={`start-timestamp: 1668780839,`} />
 
 Next, the start-timestamp variable is set to the timestamp of the beginning of the strategy, which is used as a reference point for calculating the amount of tokens that can be sent in each order.
 
-<Formatter raw={expression2} />
+<ForkableFormatter raw={expression2} />
 
 This is followed by the order-author and order-hash variables, which are used to construct a unique storage key for tracking the total amount of tokens cleared so far across executions of this order.
 
-<Formatter raw={`total-sent: get(storage-key),`} />
+<ForkableFormatter raw={`total-sent: get(storage-key),`} />
 
 The total-sent variable is then set to the value stored under the storage-key, which represents the total amount of tokens sent so far.
 
-<Formatter raw={`total-sendable-by-now: mul(dollars-per-second sub(block-timestamp() start-timestamp)),`} />
+<ForkableFormatter raw={`total-sendable-by-now: mul(dollars-per-second sub(block-timestamp() start-timestamp)),`} />
 
 This is used to calculate the total amount of tokens that can be sent by now, which is calculated by multiplying the maximum amount per second by the number of seconds since the start of the month. This output is named total-sendable-by-now.
 
-<Formatter raw={`sendable-in-this-order: sub(total-sendable-by-now total-sent),`} />
+<ForkableFormatter raw={`sendable-in-this-order: sub(total-sendable-by-now total-sent),`} />
 
 The sendable-in-this-order variable is then calculated using the sub word to subtract the total amount sent so far from the total amount that can be sent by now. This represents the amount of tokens that can be sent in this order.
 
-<Formatter raw={`arb-bounty-factor: 0.999,
+<ForkableFormatter raw={`arb-bounty-factor: 0.999,
 usdt-eth: chainlinkprice(0x00 0x00),
 amount price: sendable-in-this-order mul(usdt-eth arb-bounty-factor),`} />
 
 To get the current USDT-ETH price, we use the chainlinkprice word. This value is then multiplied by the arb-bounty-factor value to leave an arbitrage bounty, incentivising the order to be cleared.
 
-<Formatter raw={`:set(storage-key add(total-sent amount);`} />
+<ForkableFormatter raw={`:set(storage-key add(total-sent amount);`} />
 
 Finally, the set word is used to update the value stored under the storage-key by adding the amount of tokens sent in this order to the total amount sent so far. This allows you to track the total amount of tokens sent and ensure that you do not exceed the maximum amount per month.
 

--- a/src/docs/50-writing-flow-expressions/10-writing-a-flowerc20-expression.svelte.md
+++ b/src/docs/50-writing-flow-expressions/10-writing-a-flowerc20-expression.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 
 	const expression = `/**
@@ -110,32 +110,32 @@ It is important to note that you can leave a list empty, but you must still incl
 
 Here is an example expression that defines a transfer of an ERC1155 token, a mint of the FlowERC20 token, and a burn of the FlowERC20 token:
 
-<Formatter raw={expression} />
+<ForkableFormatter raw={expression} />
 
 Defining mints and burns
 To define a mint of the FlowERC20 token, you can add a line to the "mintsList" that includes the recipient address and the amount to mint. For example, the following expression defines a mint of 100 tokens to the address "recipientAddress":
 
-<Formatter raw={`mintsList: separator,
+<ForkableFormatter raw={`mintsList: separator,
 _ _: recipientAddress 100;`} />
 
 To define a burn of the FlowERC20 token, you can add a line to the "burnsList" that includes the sender address and the amount to burn. For example, the following expression defines a burn of 100 tokens from the address "senderAddress":
 
-<Formatter raw={`burnsList: separator,
+<ForkableFormatter raw={`burnsList: separator,
 _ _ _: senderAddress 0 100;`} />
 
 ## Defining token transfers
 
 First, let's look at how to define the values for an ERC1155 transfer. In this example, we'll transfer 100 tokens from address 1 to address 2. We'll use named outputs to define the values and then reference them in the transfererc1155slist.
 
-<Formatter raw={expression2} />
+<ForkableFormatter raw={expression2} />
 
 Next, let's look at how to define the values for an ERC721 transfer. In this example, we'll transfer a token with id 100 from address 1 to address 2. We'll use named outputs to define the values and then reference them in the transfererc721slist.
 
 Here's the code:
 
-<Formatter raw={expression3} />
+<ForkableFormatter raw={expression3} />
 
 Finally, let's look at how to define the values for an ERC20 transfer. In this example, we'll transfer 100 tokens from address 1 to address 2. We'll use named outputs to define the values and then reference them in the transfererc20slist.
 Here's the code:
 
-<Formatter raw={expression4} />
+<ForkableFormatter raw={expression4} />

--- a/src/docs/50-writing-flow-expressions/20-a-more-complex-flow-expression.svelte.md
+++ b/src/docs/50-writing-flow-expressions/20-a-more-complex-flow-expression.svelte.md
@@ -4,7 +4,7 @@ published: true
 ---
 
 <script>
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import { Parser } from 'rain-svelte-components/package'
 
 	const expression = `/**
@@ -62,26 +62,26 @@ _ _: sender finalAmount,`
 In Rainlang, you can use the if word to perform different actions based on a given condition. In this tutorial, we will use the if word and the erc721balanceof word to create a FlowERC20 expression that mints an amount of the token for the sender of the transaction, but only if they have at least 2 of a specific ERC721 token.
 First, let's define the named outputs that we will use in our expression. In this case, we will define the "mintAmount" output with the amount of the FlowERC20 token that we want to mint, and the "erc721Contract" output with the contract address of the ERC721 token that we want to check the balance of.
 
-<Formatter raw={`mintAmount: 100,
+<ForkableFormatter raw={`mintAmount: 100,
 erc721Contract: 0x123456,`} />
 
 Next, we will use the erc721balanceof word to get the balance of the ERC721 token for the sender of the transaction. We’ll then define our condition, which checks if the balance is greater than 1.
 
-<Formatter raw={`balance: erc721balanceof(erc721Contract, sender),
+<ForkableFormatter raw={`balance: erc721balanceof(erc721Contract, sender),
 condition: greater-than(balance 1),`} />
 
 We will then use the if word to decide what the final amount to mint is. If the condition is true, the finalAmount will be the mintAmount, otherwise 0.
 
-<Formatter raw={`finalAmount: if(condition mintAmount 0),`} />
+<ForkableFormatter raw={`finalAmount: if(condition mintAmount 0),`} />
 
 The last step is to use these values to define a mint, as part of the mints list. As we learned in the previous section, mints are defined as `\_ \_: to amount`.
 
-<Formatter raw={expression} />
+<ForkableFormatter raw={expression} />
 
 ## Including the logic in the FlowERC20 expression template
 
 The final expression would look like this:
 
-<Formatter raw={expression2} />
+<ForkableFormatter raw={expression2} />
 
 This expression will mint "mintAmount" of the FlowERC20 token to the sender if they have at least 2 of the specified ERC721 token, otherwise it will not mint any tokens. This is a simple example of how you can use the if word and named outputs to create more complex expressions with FlowERC20.

--- a/src/lib/Auth.svelte
+++ b/src/lib/Auth.svelte
@@ -1,47 +1,7 @@
 <script lang="ts">
-	import { signer, signerAddress, connected } from 'svelte-ethers-store';
+	import AuthInner from './AuthInner.svelte';
 	import { fly } from 'svelte/transition';
-	import { enhance } from '$app/forms';
-	import { Button } from 'rain-svelte-components/package';
-	import ConnectWallet from '$lib/connect-wallet/ConnectWallet.svelte';
 	import Background from '$lib/Background.svelte';
-
-	// Types
-	import type { SubmitFunction } from '@sveltejs/kit/types';
-
-	/**
-	 * Function that wrap the fetch to only ask for the message based on the address.
-	 */
-	const getMessage = async (address_: string) => {
-		const resp = await fetch(`/api/auth/request_message`, {
-			method: 'POST',
-			body: JSON.stringify({
-				address: address_
-			})
-		});
-
-		if (!resp.ok) {
-			throw new Error('It was not possible to create the message');
-		}
-		return (await resp.json()).message;
-	};
-
-	const submitFunction: SubmitFunction = async ({ data }) => {
-		// Get the message to signed based on the current address connected.
-		// Then show the pop-up from the wallet (metamask) to sign the message.
-		// If the user cancel/reject to sign the message, the submit is cancelled (no sign-in or sign-up).
-		const message = await getMessage($signerAddress);
-		const signature = await $signer.signMessage(message);
-
-		// Set the signature to the form data that will be sent to the server
-		data.set('signature', signature);
-
-		return async ({ result, update }) => {
-			if (result.type == 'success') {
-				update();
-			}
-		};
-	};
 </script>
 
 <Background>
@@ -49,31 +9,6 @@
 		class="mx-2 -mt-20 w-full max-w-sm rounded-xl border border-gray-200 bg-white p-8 sm:mx-0"
 		in:fly={{ y: 20, duration: 1000 }}
 	>
-		<div class="flex flex-col gap-y-4">
-			<!-- <div class="flex flex-col gap-y-2"> -->
-			<h1 class="text-2xl font-semibold">Welcome back</h1>
-			<!-- </div> -->
-			{#if $signerAddress && $connected}
-				<p class="text-sm text-gray-700">Sign into your account</p>
-				<form
-					method="POST"
-					action="/sign-in"
-					class="flex flex-col gap-y-4"
-					use:enhance={submitFunction}
-				>
-					<input
-						hidden
-						name="address"
-						bind:value={$signerAddress}
-						class="rounded-[10px] bg-gray-300 p-2"
-					/>
-
-					<Button variant="primary" classes="text-center">Sign in with your wallet</Button>
-				</form>
-			{:else}
-				<p class="text-sm text-gray-700">Connect your wallet to continue</p>
-				<ConnectWallet />
-			{/if}
-		</div>
+		<AuthInner />
 	</div>
 </Background>

--- a/src/lib/AuthInner.svelte
+++ b/src/lib/AuthInner.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { signer, signerAddress, connected } from 'svelte-ethers-store';
+	import { enhance } from '$app/forms';
+	import { Button } from 'rain-svelte-components/package';
+	import ConnectWallet from '$lib/connect-wallet/ConnectWallet.svelte';
+
+	// Types
+	import type { SubmitFunction } from '@sveltejs/kit/types';
+
+	/**
+	 * Function that wrap the fetch to only ask for the message based on the address.
+	 */
+	const getMessage = async (address_: string) => {
+		const resp = await fetch(`/api/auth/request_message`, {
+			method: 'POST',
+			body: JSON.stringify({
+				address: address_
+			})
+		});
+
+		if (!resp.ok) {
+			throw new Error('It was not possible to create the message');
+		}
+		return (await resp.json()).message;
+	};
+
+	const submitFunction: SubmitFunction = async ({ data }) => {
+		// Get the message to signed based on the current address connected.
+		// Then show the pop-up from the wallet (metamask) to sign the message.
+		// If the user cancel/reject to sign the message, the submit is cancelled (no sign-in or sign-up).
+		const message = await getMessage($signerAddress);
+		const signature = await $signer.signMessage(message);
+
+		// Set the signature to the form data that will be sent to the server
+		data.set('signature', signature);
+
+		return async ({ result, update }) => {
+			if (result.type == 'success') {
+				update();
+			}
+		};
+	};
+</script>
+
+<div class="flex flex-col gap-y-4">
+	<!-- <div class="flex flex-col gap-y-2"> -->
+	<h1 class="text-2xl font-semibold">Welcome back</h1>
+	<!-- </div> -->
+	{#if $signerAddress && $connected}
+		<p class="text-sm text-gray-700">Sign into your account</p>
+		<form
+			method="POST"
+			action="/sign-in"
+			class="flex flex-col gap-y-4"
+			use:enhance={submitFunction}
+		>
+			<input
+				hidden
+				name="address"
+				bind:value={$signerAddress}
+				class="rounded-[10px] bg-gray-300 p-2"
+			/>
+
+			<Button variant="primary" classes="text-center">Sign in with your wallet</Button>
+		</form>
+	{:else}
+		<p class="text-sm text-gray-700">Connect your wallet to continue</p>
+		<ConnectWallet />
+	{/if}
+</div>

--- a/src/lib/expressions/DeployedExpressionSummaryRow.svelte
+++ b/src/lib/expressions/DeployedExpressionSummaryRow.svelte
@@ -8,6 +8,7 @@
 	import Modal from 'rain-svelte-components/package/Modal.svelte';
 	import { Formatter } from '@rainprotocol/rainlang';
 	import { goto } from '$app/navigation';
+	import AuthInner from '$lib/AuthInner.svelte';
 
 	export let expression: any;
 	$: expressionToFork = { ...expression, raw_expression: Formatter.get(expression.stateConfig) };
@@ -37,6 +38,6 @@
 	{#if $page.data.session}
 		<ForkExpression expression={expressionToFork} on:saved />
 	{:else}
-		<Auth />
+		<AuthInner />
 	{/if}
 </Modal>

--- a/src/lib/expressions/ExpressionRow.svelte
+++ b/src/lib/expressions/ExpressionRow.svelte
@@ -4,11 +4,11 @@
 	import ViewTags from '$lib/ViewTags.svelte';
 	import { DisplayAddress, HoverTooltip } from 'rain-svelte-components/package';
 	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
-
 	import { LockOpen, LockClosed } from '@steeze-ui/heroicons';
 	import { Icon } from '@steeze-ui/svelte-icon';
+	import type { ExpressionRowFull } from '$lib/types/types';
 
-	export let expression: any;
+	export let expression: ExpressionRowFull;
 </script>
 
 <div class="flex w-full flex-col gap-x-4 gap-y-4 rounded-lg border border-gray-200 p-5 xl:flex-row">
@@ -29,7 +29,9 @@
 				</HoverTooltip>
 			</div>
 		</div>
-		<TimeAgo dateString={expression.created_at} />
+		{#if expression.created_at}
+			<TimeAgo dateString={expression.created_at} />
+		{/if}
 		{#if expression?.tags}
 			<ViewTags tags={expression.tags} />
 		{/if}

--- a/src/lib/expressions/ExpressionSummaryRow.svelte
+++ b/src/lib/expressions/ExpressionSummaryRow.svelte
@@ -3,7 +3,7 @@
 	import { page } from '$app/stores';
 	import Auth from '$lib/Auth.svelte';
 	import ExpressionRow from '$lib/expressions/ExpressionRow.svelte';
-	import { copyAndEmit } from '$lib/expressions/expressions';
+	import { copyAndEmit, flattenExpression } from '$lib/expressions/expressions';
 	import ForkExpression from '$lib/expressions/ForkExpression.svelte';
 	import ModalChangeVisibilty from '$lib/expressions/ModalChangeVisibilty.svelte';
 	import { supabaseClient } from '$lib/supabaseClient';
@@ -20,9 +20,9 @@
 	import Modal from 'rain-svelte-components/package/Modal.svelte';
 	import { createEventDispatcher } from 'svelte';
 	import { OverflowMenu, OverflowMenuItem } from 'rain-svelte-components/package/overflow-menu';
-	import { Icon } from '@steeze-ui/svelte-icon';
+	import type { ExpressionRowFull } from '$lib/types/types';
 
-	export let expression: any;
+	export let expression: ExpressionRowFull;
 	const dispatch = createEventDispatcher();
 
 	let deleteExpressionModal: boolean = false,
@@ -111,7 +111,7 @@
 
 <Modal bind:open={newExpModal}>
 	{#if $page.data.session}
-		<ForkExpression {expression} on:saved />
+		<ForkExpression expression={flattenExpression(expression)} on:saved />
 	{:else}
 		<Auth />
 	{/if}

--- a/src/lib/expressions/ExpressionSummaryRow.svelte
+++ b/src/lib/expressions/ExpressionSummaryRow.svelte
@@ -21,6 +21,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import { OverflowMenu, OverflowMenuItem } from 'rain-svelte-components/package/overflow-menu';
 	import type { ExpressionRowFull } from '$lib/types/types';
+	import AuthInner from '$lib/AuthInner.svelte';
 
 	export let expression: ExpressionRowFull;
 	const dispatch = createEventDispatcher();
@@ -113,6 +114,6 @@
 	{#if $page.data.session}
 		<ForkExpression expression={flattenExpression(expression)} on:saved />
 	{:else}
-		<Auth />
+		<AuthInner />
 	{/if}
 </Modal>

--- a/src/lib/expressions/ForkExpression.svelte
+++ b/src/lib/expressions/ForkExpression.svelte
@@ -22,7 +22,6 @@
 			notes: expression?.notes || ''
 		};
 
-		console.log(expressionCopy);
 		const response = await saveExpressionCopy(expressionCopy);
 		if (response.status == 400) error = 'Something went wrong';
 		if (response.status == 201 && response.data) {

--- a/src/lib/expressions/ForkExpression.svelte
+++ b/src/lib/expressions/ForkExpression.svelte
@@ -2,10 +2,11 @@
 	import { fade } from 'svelte/transition';
 	import { Button } from 'rain-svelte-components/package';
 	import { createEventDispatcher } from 'svelte';
-	import type { ExpressionRowFull } from '$lib/types/types';
+	import type { ExpressionInsert } from '$lib/types/types';
 	import { saveExpressionCopy } from '$lib/expressions/expressions';
+	import type { Database } from '$lib/types/generated-db-types';
 
-	export let expression: ExpressionRowFull;
+	export let expression: ExpressionInsert;
 	let error: string | null;
 	let newSlug: string;
 
@@ -13,14 +14,15 @@
 
 	const saveExpression = async () => {
 		error = null;
-		const expressionCopy = {
+		let expressionCopy: ExpressionInsert;
+
+		expressionCopy = {
+			...expression,
 			name: expression?.name || 'Untitled',
-			notes: expression?.notes || '',
-			contract: expression?.contract?.id,
-			contract_expression: expression?.contract_expression,
-			interpreter: expression?.interpreter?.id,
-			raw_expression: expression.raw_expression
+			notes: expression?.notes || ''
 		};
+
+		console.log(expressionCopy);
 		const response = await saveExpressionCopy(expressionCopy);
 		if (response.status == 400) error = 'Something went wrong';
 		if (response.status == 201 && response.data) {
@@ -30,12 +32,12 @@
 	};
 </script>
 
-<div class="flex flex-col gap-y-4 w-screen max-w-2xl">
+<div class="flex w-full flex-col gap-y-4 md:max-w-lg">
 	{#if !newSlug}
 		<span class="text-2xl font-semibold">Fork this expression</span>
-		<span>This will save a copy of this expression into your libary.</span>
+		<span>This will save a copy of this expression into your library.</span>
 		<div>
-			<Button variant="primary" on:click={saveExpression}>Save expression</Button>
+			<Button variant="primary" on:click={saveExpression}>Fork</Button>
 		</div>
 	{:else}
 		<div in:fade class="flex flex-col gap-y-4">

--- a/src/lib/expressions/ForkableFormatter.svelte
+++ b/src/lib/expressions/ForkableFormatter.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { Formatter as RainlangFormatter, rainterpreterOpMeta } from '@rainprotocol/rainlang';
+	import { Modal } from 'rain-svelte-components/package';
+	import type { StateConfig } from 'rain-metadata/metadata-types/expression';
+	import ForkExpression from '$lib/expressions/ForkExpression.svelte';
+	import { page } from '$app/stores';
+	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
+	import type { ExpressionInsert } from '$lib/types/types';
+	import AuthInner from '$lib/AuthInner.svelte';
+
+	export let raw: string | null = null;
+	export let stateConfig: StateConfig | null = null;
+	export let showFork: boolean = true;
+	export let showForkLabel: boolean = false;
+	export let maxHeight: string | null = null;
+	export let contract: string | null = null;
+	export let contractExpression: string | null = null;
+
+	let expression: ExpressionInsert;
+	let open: boolean = false;
+
+	$: if (stateConfig)
+		buildExpression(RainlangFormatter.get(stateConfig, { opmeta: rainterpreterOpMeta }));
+
+	$: if (raw) buildExpression(raw);
+
+	const buildExpression = (raw: string) => {
+		expression = {
+			name: 'Untitled',
+			notes: '',
+			contract,
+			contract_expression: contractExpression,
+			interpreter: '761f3744-fe08-4e71-b38c-faaf7b447455',
+			raw_expression: raw
+		};
+	};
+
+	const handleFork = () => {
+		open = true;
+	};
+</script>
+
+<Formatter {raw} {stateConfig} {showFork} {showForkLabel} {maxHeight} on:fork={handleFork} />
+
+<Modal bind:open>
+	{#if $page.data.session}
+		<ForkExpression {expression} on:saved />
+	{:else}
+		<AuthInner />
+	{/if}
+</Modal>

--- a/src/lib/expressions/SaveExpression.svelte
+++ b/src/lib/expressions/SaveExpression.svelte
@@ -43,7 +43,7 @@
 	};
 </script>
 
-<div class="flex flex-col gap-y-4 w-screen max-w-2xl">
+<div class="flex w-screen max-w-2xl flex-col gap-y-4">
 	{#if !newSlug}
 		<span class="text-2xl font-semibold"
 			>{#if forking}Fork this expression{:else}Save this expression{/if}</span
@@ -54,7 +54,7 @@
 		/>
 		<Pills><span class="text-sm">{presaveExpression.interpreter.metadata.name}</span></Pills>
 		<div class="max-h-80 overflow-y-scroll">
-			<Formatter raw={presaveExpression.raw_expression} />
+			<Formatter raw={presaveExpression.raw_expression} showFork={false} />
 		</div>
 		<Input bind:value={presaveExpression.name}>
 			<svelte:fragment slot="label">Name</svelte:fragment>

--- a/src/lib/expressions/expressions.ts
+++ b/src/lib/expressions/expressions.ts
@@ -1,7 +1,7 @@
 import { matchContracts, matchInterpreters } from "$lib/match-addresses";
 import { supabaseClient as _supabaseClient } from "$lib/supabaseClient";
 import type { Database } from "$lib/types/generated-db-types";
-import type { ExpressionRow } from "$lib/types/types";
+import type { ExpressionInsert, ExpressionRow, ExpressionRowFull } from "$lib/types/types";
 import { QueryAccountsFromArray, QueryExpression, Subgraphs } from "$lib/utils";
 import type { TypedSupabaseClient } from "@supabase/auth-helpers-sveltekit/dist/types";
 import type { PostgrestSingleResponse } from "@supabase/supabase-js";
@@ -10,11 +10,26 @@ import { error as sveltekitError } from '@sveltejs/kit';
 import { ethers } from "ethers";
 import { toast } from "@zerodevx/svelte-toast";
 
-export const createNewExpression = async (expression: Omit<Database['public']['Tables']['draft_expressions']['Insert'], 'raw_expression' | 'notes' | 'name'>) => {
+/**
+ * Create a new blank expression, with no raw string, notes or name.
+ * 
+ * @param expression - the expression
+ */
+export const createNewExpression = async (expression: Omit<ExpressionInsert, 'raw_expression' | 'notes' | 'name'>) => {
     const _expression = { ...expression, notes: '', raw_expression: '', name: 'Untitled expression' }
     return await saveExpression(_expression)
 }
-export const saveExpression = async (expression: Database['public']['Tables']['draft_expressions']['Insert']): Promise<PostgrestSingleResponse<ExpressionRow>> => {
+
+/**
+ * Save an expression
+ * 
+ * @param expression - the expression
+ */
+export const saveExpression = async (expression: ExpressionInsert): Promise<PostgrestSingleResponse<ExpressionRow>> => {
+    delete expression.id
+    delete expression.sharable_slug
+    expression.public = false
+
     const newExpression = await _supabaseClient
         .from('draft_expressions_w')
         .insert(expression)
@@ -22,11 +37,29 @@ export const saveExpression = async (expression: Database['public']['Tables']['d
     return newExpression;
 };
 
-export const saveExpressionCopy = async (expression: Database['public']['Tables']['draft_expressions']['Insert']): Promise<ReturnType<typeof saveExpression>> => {
+/**
+ * Save a copy of an expression, this updates the name to "Copy of {expression_name}"
+ * 
+ * @param expression - the expression
+ */
+export const saveExpressionCopy = async (expression: ExpressionInsert): Promise<ReturnType<typeof saveExpression>> => {
     const expressionCopy = { ...expression, name: `Copy of ${expression.name}` }
     return await saveExpression(expressionCopy)
 }
 
+/**
+ * Convert an expression from the ExpressionRowFull type to the ExpressionInsert type
+ * This is necessary, because the ExpressionRowFull type is fully joined on contract, interpreter etc,
+ * however when we insert we just need id's for those fields.
+ */
+export const flattenExpression = (expression: ExpressionRowFull): ExpressionInsert => {
+    return {
+        ...expression,
+        contract: expression?.contract?.id,
+        interpreter: expression?.interpreter?.id,
+        user_id: expression?.user_id.id
+    }
+}
 /**
  * Gets all deployed expressions for a user.
  * This function gets all the user's linked wallets and fetches the deployed expressions from the subgraph.

--- a/src/lib/types/types.ts
+++ b/src/lib/types/types.ts
@@ -9,6 +9,8 @@ export type ContractRow = Database['public']['Tables']['contracts']['Row']
 export type ProfileRow = Database['public']['Tables']['wallet_users']['Row']
 export type InterpreterRow = Database['public']['Tables']['interpreters']['Row']
 
+export type ExpressionInsert = Database['public']['Tables']['draft_expressions_w']['Insert']
+
 export type ContractRowFull = Nest<Nest<Nest<ContractRow, 'project', ProjectRow>, 'metadata', ContractMetadata>, 'abi', { abi: Abi }>
 export type ExpressionRowFull = Nest<Nest<Nest<Nest<ExpressionRow, 'contract', ContractRowFull | null>, 'user_id', ProfileRow>, 'interpreter', InterpreterRowFull>, 'saved_context', SavedContext>
 export type InterpreterRowFull = Nest<InterpreterRow, 'metadata', InterpreterMetadata>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import { ArrowUpRight } from '@steeze-ui/heroicons';
 	import { goto } from '$app/navigation';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 
 	let show = false;
 	onMount(() => {
@@ -89,7 +90,11 @@
 			</div>
 			<div class="w-full flex-shrink-0 md:w-3/5">
 				{#key activeExample}
-					<Formatter raw={expressionExamples[activeExample].expression} maxHeight="400px" />
+					<ForkableFormatter
+						raw={expressionExamples[activeExample].expression}
+						maxHeight="400px"
+						showForkLabel
+					/>
 				{/key}
 			</div>
 		</div>

--- a/src/routes/contracts/+page.svelte
+++ b/src/routes/contracts/+page.svelte
@@ -18,7 +18,3 @@
 		</div>
 	</div>
 </Background>
-
-<!-- <div class="w-full overflow-hidden">
-	<pre>{JSON.stringify($page.data, null, 2)}</pre>
-</div> -->

--- a/src/routes/contracts/[slug]/+page.svelte
+++ b/src/routes/contracts/[slug]/+page.svelte
@@ -2,8 +2,6 @@
 	import { page } from '$app/stores';
 	import PageHeader from '$lib/PageHeader.svelte';
 	import ProjectTag from '$lib/ProjectTag.svelte';
-	import { Button } from 'rain-svelte-components/package';
-	import AutoAbiFormSeparated from 'rain-svelte-components/package/auto-abi-form/AutoAbiFormSeparated.svelte';
 	import Sidebar from './Sidebar.svelte';
 	import Pills from 'rain-svelte-components/package/Pills.svelte';
 	import { Tabs, TabList, TabPanel, Tab } from 'rain-svelte-components/package/tabs/tabs';
@@ -11,10 +9,8 @@
 	import Write from './Write.svelte';
 	import Summary from './Summary.svelte';
 
-	$: project = $page.data.contract.project;
 	$: contract = $page.data.contract;
-	$: metadata = $page.data.contract.metadata;
-	$: abi = $page.data.contract.abi;
+	$: ({ project, metadata, abi } = contract);
 </script>
 
 <PageHeader>
@@ -48,9 +44,9 @@
 				<Summary {abi} {metadata} />
 			</TabPanel>
 			<TabPanel>
-				<Write {abi} {metadata} {contract} {project} />
+				<Write {abi} {metadata} {contract} />
 			</TabPanel>
 		</div>
-		<div class="py-8 lg:w-1/3"><Sidebar /></div>
+		<div class="py-8 lg:w-1/3"><Sidebar {contract} /></div>
 	</div>
 </Tabs>

--- a/src/routes/contracts/[slug]/Sidebar.svelte
+++ b/src/routes/contracts/[slug]/Sidebar.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { Heart, ArrowUp, ArrowDown, ChatBubbleLeft } from '@steeze-ui/heroicons';
 	import { Section, SectionBody } from 'rain-svelte-components/package/section';
-	import Formatter from 'rain-svelte-components/package/formatter/Formatter.svelte';
 	import { DisplayAddress, Ring, Modal } from 'rain-svelte-components/package';
 
 	import { page } from '$app/stores';
@@ -16,6 +15,10 @@
 	import { supabaseClient } from '$lib/supabaseClient';
 
 	import type { UserLikes, ExpressionLikes, AccountData } from './types';
+	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
+	import type { ContractRowFull } from '$lib/types/types';
+
+	export let contract: ContractRowFull;
 
 	let expressionsToShow: any[] = [];
 	let isLoading = true;
@@ -122,12 +125,13 @@
 								<div
 									class="overflow-hidden rounded-[5px] bg-neutral-100 font-mono text-[12px] leading-4 tracking-[-0.01em]"
 								>
-									<Formatter
+									<ForkableFormatter
 										maxHeight="150px"
 										stateConfig={{
 											sources: config.sources,
 											constants: config.constants
 										}}
+										contract={contract.id}
 									/>
 								</div>
 								<div class="flex items-center gap-x-3.5 text-[13px] text-neutral-500">

--- a/src/routes/contracts/[slug]/Sidebar.svelte
+++ b/src/routes/contracts/[slug]/Sidebar.svelte
@@ -17,6 +17,7 @@
 	import type { UserLikes, ExpressionLikes, AccountData } from './types';
 	import ForkableFormatter from '$lib/expressions/ForkableFormatter.svelte';
 	import type { ContractRowFull } from '$lib/types/types';
+	import AuthInner from '$lib/AuthInner.svelte';
 
 	export let contract: ContractRowFull;
 
@@ -210,5 +211,5 @@
 </div>
 
 <Modal bind:open={openAuthModal}>
-	<Auth />
+	<AuthInner />
 </Modal>

--- a/src/routes/contracts/[slug]/Write.svelte
+++ b/src/routes/contracts/[slug]/Write.svelte
@@ -22,6 +22,7 @@
 	} from './write';
 	import type { ContractRowFull, ExpressionRowFull, InterpreterRowFull } from '$lib/types/types';
 	import HelpPanel from '$lib/HelpPanel.svelte';
+	import AuthInner from '$lib/AuthInner.svelte';
 
 	export let metadata: ContractMetadata, abi: { abi: Abi }, contract: ContractRowFull;
 
@@ -251,7 +252,7 @@
 	{#if $page.data.session}
 		<SaveExpression {presaveExpression} />
 	{:else}
-		<Auth />
+		<AuthInner />
 	{/if}
 </Modal>
 
@@ -263,7 +264,7 @@
 	{#if $page.data.session}
 		<LoadExpressionModal on:select={loadSelectedExpression} {contract} {expressionComponentName} />
 	{:else}
-		<Auth />
+		<AuthInner />
 	{/if}
 </Modal>
 

--- a/src/routes/contracts/[slug]/Write.svelte
+++ b/src/routes/contracts/[slug]/Write.svelte
@@ -20,10 +20,10 @@
 		getNameFromChainId,
 		getWriteMethods
 	} from './write';
-	import type { ExpressionRowFull, InterpreterRowFull } from '$lib/types/types';
+	import type { ContractRowFull, ExpressionRowFull, InterpreterRowFull } from '$lib/types/types';
 	import HelpPanel from '$lib/HelpPanel.svelte';
 
-	export let metadata: ContractMetadata, abi: { abi: Abi }, contract: any;
+	export let metadata: ContractMetadata, abi: { abi: Abi }, contract: ContractRowFull;
 
 	let result: any = []; // the state of the the form
 
@@ -211,14 +211,14 @@
 					showInterpreterFields={false}
 				/>
 			{/key}
-			<div class="flex flex-col gap-y-4 p-4 border-gray-300 rounded-lg border mt-8">
+			<div class="mt-8 flex flex-col gap-y-4 rounded-lg border border-gray-300 p-4">
 				{#if !$signer}
 					<div class="self-center">
 						<ConnectWallet />
 					</div>
 				{:else}
-					<div class="flex gap-x-2 items-center">
-						<div class="w-3 h-3 rounded-full bg-green-600" />
+					<div class="flex items-center gap-x-2">
+						<div class="h-3 w-3 rounded-full bg-green-600" />
 						<span>Connected to {connectedChainName}</span>
 					</div>
 					<div class="flex flex-col gap-y-2">

--- a/src/routes/expression/[address]/+page.svelte
+++ b/src/routes/expression/[address]/+page.svelte
@@ -12,6 +12,7 @@
 	import ForkExpression from '$lib/expressions/ForkExpression.svelte';
 	import SocialButton from '$lib/SocialButton.svelte';
 	import { supabaseClient } from '$lib/supabaseClient';
+	import AuthInner from '$lib/AuthInner.svelte';
 
 	$: expression = $page.data.expression;
 	$: user = $page.data.user;
@@ -52,7 +53,7 @@
 </script>
 
 <PageHeader>
-	<div class="w-full flex justify-between items-center container mx-auto">
+	<div class="container mx-auto flex w-full items-center justify-between">
 		<div class="flex flex-col gap-y-2">
 			<span class="text-sm text-gray-500">On-chain expression</span>
 			<span class="font-mono text-xl">{sgQuery.id}</span>
@@ -87,18 +88,18 @@
 
 <div class="container mx-auto">
 	<div class="mt-8">
-		<div class="gap-y-4 grid grid-cols-2 gap-8">
+		<div class="grid grid-cols-2 gap-8 gap-y-4">
 			<div class="flex flex-col gap-y-4">
-				<div class="font-semibold text-xl">Writer's notes</div>
+				<div class="text-xl font-semibold">Writer's notes</div>
 				<div class="whitespace-pre-line">
 					{expression.notes || `The writer of this expression hasn't appended any metadata.`}
 				</div>
-				<div class="flex flex-col gap-y-2 border-t border-gray-200 pt-4 mt-4 items-start">
+				<div class="mt-4 flex flex-col items-start gap-y-2 border-t border-gray-200 pt-4">
 					<ExpressionEnv {expression} />
 				</div>
 			</div>
 			<div>
-				<div class="w-full flex flex-col gap-y-4">
+				<div class="flex w-full flex-col gap-y-4">
 					<Formatter stateConfig={expression.stateConfig} />
 				</div>
 			</div>
@@ -110,8 +111,8 @@
 	{#if $page.data.session}
 		<ForkExpression expression={expressionToFork} />
 	{:else}
-		<Auth />
+		<AuthInner />
 	{/if}
 </Modal>
 
-<Modal bind:open={openSignInModal}><Auth /></Modal>
+<Modal bind:open={openSignInModal}><AuthInner /></Modal>

--- a/src/routes/expression/draft/[slug]/+page.server.ts
+++ b/src/routes/expression/draft/[slug]/+page.server.ts
@@ -57,7 +57,7 @@ export async function load(event) {
 			user_id: userQuery.data,
 			contract: contractQuery?.data as unknown as ContractRowFull,
 			interpreter: interpreterQuery.data,
-			userLike
-		}
+		},
+		userLike
 	};
 }

--- a/src/routes/expression/draft/[slug]/+page.svelte
+++ b/src/routes/expression/draft/[slug]/+page.svelte
@@ -16,25 +16,20 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 	import SocialButton from '$lib/SocialButton.svelte';
 	import { supabaseClient } from '$lib/supabaseClient';
+	import { flattenExpression } from '$lib/expressions/expressions';
 
 	$: expression = $page.data.expression;
 	$: user = $page.data.expression.user_id;
-	$: contract = $page.data.expression.contract;
-	$: interpreter = $page.data.expression.interpreter;
 	$: tags = $page.data.expression?.tags;
-	$: userLike = $page.data.expression?.userLike;
+	$: userLike = $page.data.userLike;
 
 	let session = $page.data.session;
-	let openNewExpModal: boolean = false;
+	let openForkModal: boolean = false;
 	let openSignInModal: boolean = false;
 	let changeVisiblityModal: boolean = false;
 
 	const fork = () => {
-		if (session) {
-			openNewExpModal = true;
-		} else {
-			openSignInModal = true;
-		}
+		openForkModal = true;
 	};
 
 	const clickLike = async () => {
@@ -154,8 +149,10 @@
 	}}
 />
 
-<Modal bind:open={openNewExpModal}>
-	<ForkExpression {expression} />
+<Modal bind:open={openForkModal}>
+	{#if $page.data.session}
+		<ForkExpression expression={flattenExpression(expression)} on:saved />
+	{:else}
+		<Auth />
+	{/if}
 </Modal>
-
-<Modal bind:open={openSignInModal}><Auth /></Modal>

--- a/src/routes/expression/draft/[slug]/+page.svelte
+++ b/src/routes/expression/draft/[slug]/+page.svelte
@@ -139,7 +139,7 @@
 			</div>
 			<div class="col-span-4">
 				<div class="flex w-full flex-col gap-y-4">
-					<Formatter raw={expression.raw_expression} />
+					<Formatter raw={expression.raw_expression} showFork={false} />
 				</div>
 			</div>
 		</div>

--- a/src/routes/expression/draft/[slug]/+page.svelte
+++ b/src/routes/expression/draft/[slug]/+page.svelte
@@ -17,6 +17,7 @@
 	import SocialButton from '$lib/SocialButton.svelte';
 	import { supabaseClient } from '$lib/supabaseClient';
 	import { flattenExpression } from '$lib/expressions/expressions';
+	import AuthInner from '$lib/AuthInner.svelte';
 
 	$: expression = $page.data.expression;
 	$: user = $page.data.expression.user_id;
@@ -153,6 +154,6 @@
 	{#if $page.data.session}
 		<ForkExpression expression={flattenExpression(expression)} on:saved />
 	{:else}
-		<Auth />
+		<AuthInner />
 	{/if}
 </Modal>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,9 +4652,9 @@ quick-lru@^5.1.1:
     ethers "^5.5.2"
     prettier "^2.6.2"
 
-"rain-svelte-components@https://github.com/rainprotocol/rain-svelte-components#44320c53b8d6d6091461474292440a2dfdb5a64b":
+"rain-svelte-components@https://github.com/rainprotocol/rain-svelte-components#d8e8378c0f825b250941d138fc19be49870ef87f":
   version "0.0.1"
-  resolved "https://github.com/rainprotocol/rain-svelte-components#44320c53b8d6d6091461474292440a2dfdb5a64b"
+  resolved "https://github.com/rainprotocol/rain-svelte-components#d8e8378c0f825b250941d138fc19be49870ef87f"
   dependencies:
     "@formkit/auto-animate" "^1.0.0-beta.3"
     "@metamask/jazzicon" "^2.0.0"


### PR DESCRIPTION
This PR makes expressions forkable across the site when you see the fork button on a formatted expression. A new component ForkableFormatter handles this so we don't need to duplicate the forking logic in the various places formatted expressions can be found (e.g. homepage, contract page sidebar etc).

This also required some refactoring for the utility functions for saving and saving copies of expressions.

Better typing was added to the ExpressionRow and ExpressionSummaryRow components.