### PR TITLE
wip using contracts definitions class to get abis

### DIFF
--- a/src/lib/abis/clone-factory/index.ts
+++ b/src/lib/abis/clone-factory/index.ts
@@ -1,0 +1,70 @@
+import { ethers } from 'ethers';
+
+const address = '0xdbcf05952ebb83feaf98a63923f3adcf856b0d76';
+
+const abi = [
+	{
+		inputs: [],
+		name: 'ZeroImplementation',
+		type: 'error'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'implementation',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'clone',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'bytes',
+				name: 'data',
+				type: 'bytes'
+			}
+		],
+		name: 'NewClone',
+		type: 'event'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'implementation_',
+				type: 'address'
+			},
+			{
+				internalType: 'bytes',
+				name: 'data_',
+				type: 'bytes'
+			}
+		],
+		name: 'clone',
+		outputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	}
+];
+
+export const cloneFactory = new ethers.Contract(address, abi);
+
+export default cloneFactory;

--- a/src/lib/abis/flow-erc20-factory/index.ts
+++ b/src/lib/abis/flow-erc20-factory/index.ts
@@ -1,0 +1,1139 @@
+import type { ImplementationDataFormat } from '../types';
+
+const abi = [
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'bytes',
+						name: 'callerMeta',
+						type: 'bytes'
+					},
+					{
+						internalType: 'address',
+						name: 'deployer',
+						type: 'address'
+					}
+				],
+				internalType: 'struct InterpreterCallerV1ConstructionConfig',
+				name: 'config_',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'constructor'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'flowMinOutputs_',
+				type: 'uint256'
+			}
+		],
+		name: 'BadMinStackLength',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'i',
+				type: 'uint256'
+			}
+		],
+		name: 'InvalidSignature',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'InvalidTransfer',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'expectedHash',
+				type: 'bytes32'
+			},
+			{
+				internalType: 'bytes32',
+				name: 'actualHash',
+				type: 'bytes32'
+			}
+		],
+		name: 'UnexpectedMetaHash',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'unregisteredHash',
+				type: 'bytes32'
+			}
+		],
+		name: 'UnregisteredFlow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC1155Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC20Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC721Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedNativeFlow',
+		type: 'error'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'spender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'value',
+				type: 'uint256'
+			}
+		],
+		name: 'Approval',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256[][]',
+				name: 'context',
+				type: 'uint256[][]'
+			}
+		],
+		name: 'Context',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				indexed: false,
+				internalType: 'struct Evaluable',
+				name: 'evaluable',
+				type: 'tuple'
+			}
+		],
+		name: 'FlowInitialized',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'string',
+						name: 'name',
+						type: 'string'
+					},
+					{
+						internalType: 'string',
+						name: 'symbol',
+						type: 'string'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IExpressionDeployerV1',
+								name: 'deployer',
+								type: 'address'
+							},
+							{
+								internalType: 'bytes[]',
+								name: 'sources',
+								type: 'bytes[]'
+							},
+							{
+								internalType: 'uint256[]',
+								name: 'constants',
+								type: 'uint256[]'
+							}
+						],
+						internalType: 'struct EvaluableConfig',
+						name: 'evaluableConfig',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IExpressionDeployerV1',
+								name: 'deployer',
+								type: 'address'
+							},
+							{
+								internalType: 'bytes[]',
+								name: 'sources',
+								type: 'bytes[]'
+							},
+							{
+								internalType: 'uint256[]',
+								name: 'constants',
+								type: 'uint256[]'
+							}
+						],
+						internalType: 'struct EvaluableConfig[]',
+						name: 'flowConfig',
+						type: 'tuple[]'
+					}
+				],
+				indexed: false,
+				internalType: 'struct FlowERC20Config',
+				name: 'config',
+				type: 'tuple'
+			}
+		],
+		name: 'Initialize',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'uint8',
+				name: 'version',
+				type: 'uint8'
+			}
+		],
+		name: 'Initialized',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'bytes',
+				name: 'callerMeta',
+				type: 'bytes'
+			}
+		],
+		name: 'InterpreterCallerMeta',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'from',
+				type: 'address'
+			},
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'value',
+				type: 'uint256'
+			}
+		],
+		name: 'Transfer',
+		type: 'event'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'spender',
+				type: 'address'
+			}
+		],
+		name: 'allowance',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'spender',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'amount',
+				type: 'uint256'
+			}
+		],
+		name: 'approve',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'account',
+				type: 'address'
+			}
+		],
+		name: 'balanceOf',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [],
+		name: 'decimals',
+		outputs: [
+			{
+				internalType: 'uint8',
+				name: '',
+				type: 'uint8'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'spender',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'subtractedValue',
+				type: 'uint256'
+			}
+		],
+		name: 'decreaseAllowance',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				internalType: 'struct Evaluable',
+				name: 'evaluable_',
+				type: 'tuple'
+			},
+			{
+				internalType: 'uint256[]',
+				name: 'callerContext_',
+				type: 'uint256[]'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'signer',
+						type: 'address'
+					},
+					{
+						internalType: 'bytes',
+						name: 'signature',
+						type: 'bytes'
+					},
+					{
+						internalType: 'uint256[]',
+						name: 'context',
+						type: 'uint256[]'
+					}
+				],
+				internalType: 'struct SignedContext[]',
+				name: 'signedContexts_',
+				type: 'tuple[]'
+			}
+		],
+		name: 'flow',
+		outputs: [
+			{
+				components: [
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'amount',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC20SupplyChange[]',
+						name: 'mints',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'amount',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC20SupplyChange[]',
+						name: 'burns',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct NativeTransfer[]',
+								name: 'native',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC20Transfer[]',
+								name: 'erc20',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC721Transfer[]',
+								name: 'erc721',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC1155Transfer[]',
+								name: 'erc1155',
+								type: 'tuple[]'
+							}
+						],
+						internalType: 'struct FlowTransfer',
+						name: 'flow',
+						type: 'tuple'
+					}
+				],
+				internalType: 'struct FlowERC20IO',
+				name: '',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'payable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'spender',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'addedValue',
+				type: 'uint256'
+			}
+		],
+		name: 'increaseAllowance',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes',
+				name: 'data_',
+				type: 'bytes'
+			}
+		],
+		name: 'initialize',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'data',
+				type: 'bytes[]'
+			}
+		],
+		name: 'multicall',
+		outputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'results',
+				type: 'bytes[]'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [],
+		name: 'name',
+		outputs: [
+			{
+				internalType: 'string',
+				name: '',
+				type: 'string'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256[]',
+				name: '',
+				type: 'uint256[]'
+			},
+			{
+				internalType: 'uint256[]',
+				name: '',
+				type: 'uint256[]'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC1155BatchReceived',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC1155Received',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC721Received',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				internalType: 'struct Evaluable',
+				name: 'evaluable_',
+				type: 'tuple'
+			},
+			{
+				internalType: 'uint256[]',
+				name: 'callerContext_',
+				type: 'uint256[]'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'signer',
+						type: 'address'
+					},
+					{
+						internalType: 'bytes',
+						name: 'signature',
+						type: 'bytes'
+					},
+					{
+						internalType: 'uint256[]',
+						name: 'context',
+						type: 'uint256[]'
+					}
+				],
+				internalType: 'struct SignedContext[]',
+				name: 'signedContexts_',
+				type: 'tuple[]'
+			}
+		],
+		name: 'previewFlow',
+		outputs: [
+			{
+				components: [
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'amount',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC20SupplyChange[]',
+						name: 'mints',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'amount',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC20SupplyChange[]',
+						name: 'burns',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct NativeTransfer[]',
+								name: 'native',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC20Transfer[]',
+								name: 'erc20',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC721Transfer[]',
+								name: 'erc721',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC1155Transfer[]',
+								name: 'erc1155',
+								type: 'tuple[]'
+							}
+						],
+						internalType: 'struct FlowTransfer',
+						name: 'flow',
+						type: 'tuple'
+					}
+				],
+				internalType: 'struct FlowERC20IO',
+				name: '',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes4',
+				name: 'interfaceId',
+				type: 'bytes4'
+			}
+		],
+		name: 'supportsInterface',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [],
+		name: 'symbol',
+		outputs: [
+			{
+				internalType: 'string',
+				name: '',
+				type: 'string'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [],
+		name: 'totalSupply',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'amount',
+				type: 'uint256'
+			}
+		],
+		name: 'transfer',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'from',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'amount',
+				type: 'uint256'
+			}
+		],
+		name: 'transferFrom',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		stateMutability: 'payable',
+		type: 'receive'
+	}
+];
+
+const tupleFormat =
+	'tuple(string name, string symbol, tuple(address deployer, bytes[] sources, uint256[] constants) evaluableConfig, tuple(address deployer, bytes[] sources, uint256[] constants)[] flowConfig)';
+
+const FlowERC20: ImplementationDataFormat = {
+	abi,
+	initializeTuple: tupleFormat,
+	type: 'implementation'
+};
+
+export default FlowERC20;

--- a/src/lib/abis/flow-erc721-factory/index.ts
+++ b/src/lib/abis/flow-erc721-factory/index.ts
@@ -1,0 +1,1185 @@
+import type { ImplementationDataFormat } from "../types";
+
+export const abi = [
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'bytes',
+						name: 'callerMeta',
+						type: 'bytes'
+					},
+					{
+						internalType: 'address',
+						name: 'deployer',
+						type: 'address'
+					}
+				],
+				internalType: 'struct InterpreterCallerV1ConstructionConfig',
+				name: 'config_',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'constructor'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'flowMinOutputs_',
+				type: 'uint256'
+			}
+		],
+		name: 'BadMinStackLength',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'BurnerNotOwner',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'i',
+				type: 'uint256'
+			}
+		],
+		name: 'InvalidSignature',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'InvalidTransfer',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'expectedHash',
+				type: 'bytes32'
+			},
+			{
+				internalType: 'bytes32',
+				name: 'actualHash',
+				type: 'bytes32'
+			}
+		],
+		name: 'UnexpectedMetaHash',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'unregisteredHash',
+				type: 'bytes32'
+			}
+		],
+		name: 'UnregisteredFlow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC1155Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC20Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC721Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedNativeFlow',
+		type: 'error'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'approved',
+				type: 'address'
+			},
+			{
+				indexed: true,
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'Approval',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'operator',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'bool',
+				name: 'approved',
+				type: 'bool'
+			}
+		],
+		name: 'ApprovalForAll',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256[][]',
+				name: 'context',
+				type: 'uint256[][]'
+			}
+		],
+		name: 'Context',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				indexed: false,
+				internalType: 'struct Evaluable',
+				name: 'evaluable',
+				type: 'tuple'
+			}
+		],
+		name: 'FlowInitialized',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'string',
+						name: 'name',
+						type: 'string'
+					},
+					{
+						internalType: 'string',
+						name: 'symbol',
+						type: 'string'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IExpressionDeployerV1',
+								name: 'deployer',
+								type: 'address'
+							},
+							{
+								internalType: 'bytes[]',
+								name: 'sources',
+								type: 'bytes[]'
+							},
+							{
+								internalType: 'uint256[]',
+								name: 'constants',
+								type: 'uint256[]'
+							}
+						],
+						internalType: 'struct EvaluableConfig',
+						name: 'evaluableConfig',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IExpressionDeployerV1',
+								name: 'deployer',
+								type: 'address'
+							},
+							{
+								internalType: 'bytes[]',
+								name: 'sources',
+								type: 'bytes[]'
+							},
+							{
+								internalType: 'uint256[]',
+								name: 'constants',
+								type: 'uint256[]'
+							}
+						],
+						internalType: 'struct EvaluableConfig[]',
+						name: 'flowConfig',
+						type: 'tuple[]'
+					}
+				],
+				indexed: false,
+				internalType: 'struct FlowERC721Config',
+				name: 'config',
+				type: 'tuple'
+			}
+		],
+		name: 'Initialize',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'uint8',
+				name: 'version',
+				type: 'uint8'
+			}
+		],
+		name: 'Initialized',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'bytes',
+				name: 'callerMeta',
+				type: 'bytes'
+			}
+		],
+		name: 'InterpreterCallerMeta',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'from',
+				type: 'address'
+			},
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				indexed: true,
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'Transfer',
+		type: 'event'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'approve',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			}
+		],
+		name: 'balanceOf',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				internalType: 'struct Evaluable',
+				name: 'evaluable_',
+				type: 'tuple'
+			},
+			{
+				internalType: 'uint256[]',
+				name: 'callerContext_',
+				type: 'uint256[]'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'signer',
+						type: 'address'
+					},
+					{
+						internalType: 'bytes',
+						name: 'signature',
+						type: 'bytes'
+					},
+					{
+						internalType: 'uint256[]',
+						name: 'context',
+						type: 'uint256[]'
+					}
+				],
+				internalType: 'struct SignedContext[]',
+				name: 'signedContexts_',
+				type: 'tuple[]'
+			}
+		],
+		name: 'flow',
+		outputs: [
+			{
+				components: [
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'id',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC721SupplyChange[]',
+						name: 'mints',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'id',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC721SupplyChange[]',
+						name: 'burns',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct NativeTransfer[]',
+								name: 'native',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC20Transfer[]',
+								name: 'erc20',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC721Transfer[]',
+								name: 'erc721',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC1155Transfer[]',
+								name: 'erc1155',
+								type: 'tuple[]'
+							}
+						],
+						internalType: 'struct FlowTransfer',
+						name: 'flow',
+						type: 'tuple'
+					}
+				],
+				internalType: 'struct FlowERC721IO',
+				name: '',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'payable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'getApproved',
+		outputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes',
+				name: 'data_',
+				type: 'bytes'
+			}
+		],
+		name: 'initialize',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'operator',
+				type: 'address'
+			}
+		],
+		name: 'isApprovedForAll',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'data',
+				type: 'bytes[]'
+			}
+		],
+		name: 'multicall',
+		outputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'results',
+				type: 'bytes[]'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [],
+		name: 'name',
+		outputs: [
+			{
+				internalType: 'string',
+				name: '',
+				type: 'string'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256[]',
+				name: '',
+				type: 'uint256[]'
+			},
+			{
+				internalType: 'uint256[]',
+				name: '',
+				type: 'uint256[]'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC1155BatchReceived',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC1155Received',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC721Received',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'ownerOf',
+		outputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				internalType: 'struct Evaluable',
+				name: 'evaluable_',
+				type: 'tuple'
+			},
+			{
+				internalType: 'uint256[]',
+				name: 'callerContext_',
+				type: 'uint256[]'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'signer',
+						type: 'address'
+					},
+					{
+						internalType: 'bytes',
+						name: 'signature',
+						type: 'bytes'
+					},
+					{
+						internalType: 'uint256[]',
+						name: 'context',
+						type: 'uint256[]'
+					}
+				],
+				internalType: 'struct SignedContext[]',
+				name: 'signedContexts_',
+				type: 'tuple[]'
+			}
+		],
+		name: 'previewFlow',
+		outputs: [
+			{
+				components: [
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'id',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC721SupplyChange[]',
+						name: 'mints',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'account',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'id',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC721SupplyChange[]',
+						name: 'burns',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct NativeTransfer[]',
+								name: 'native',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC20Transfer[]',
+								name: 'erc20',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC721Transfer[]',
+								name: 'erc721',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'from',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'to',
+										type: 'address'
+									},
+									{
+										internalType: 'uint256',
+										name: 'id',
+										type: 'uint256'
+									},
+									{
+										internalType: 'uint256',
+										name: 'amount',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct ERC1155Transfer[]',
+								name: 'erc1155',
+								type: 'tuple[]'
+							}
+						],
+						internalType: 'struct FlowTransfer',
+						name: 'flow',
+						type: 'tuple'
+					}
+				],
+				internalType: 'struct FlowERC721IO',
+				name: '',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'from',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'safeTransferFrom',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'from',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: 'data',
+				type: 'bytes'
+			}
+		],
+		name: 'safeTransferFrom',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'operator',
+				type: 'address'
+			},
+			{
+				internalType: 'bool',
+				name: 'approved',
+				type: 'bool'
+			}
+		],
+		name: 'setApprovalForAll',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes4',
+				name: 'interfaceId',
+				type: 'bytes4'
+			}
+		],
+		name: 'supportsInterface',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [],
+		name: 'symbol',
+		outputs: [
+			{
+				internalType: 'string',
+				name: '',
+				type: 'string'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'tokenURI',
+		outputs: [
+			{
+				internalType: 'string',
+				name: '',
+				type: 'string'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'from',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'to',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'tokenId',
+				type: 'uint256'
+			}
+		],
+		name: 'transferFrom',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		stateMutability: 'payable',
+		type: 'receive'
+	}
+];
+
+export const tupleFormat =
+	'tuple(tuple(address deployer, bytes[] sources, uint256[] constants) dummyConfig, tuple(address deployer, bytes[] sources, uint256[] constants)[] config)';
+
+const FlowERC721: ImplementationDataFormat = {
+	abi,
+	initializeTuple: tupleFormat,
+	type: 'implementation'
+};
+
+export default FlowERC721;

--- a/src/lib/abis/flow-factory/index.ts
+++ b/src/lib/abis/flow-factory/index.ts
@@ -1,0 +1,627 @@
+import type { ImplementationDataFormat } from '../types';
+
+export const abi = [
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'bytes',
+						name: 'callerMeta',
+						type: 'bytes'
+					},
+					{
+						internalType: 'address',
+						name: 'deployer',
+						type: 'address'
+					}
+				],
+				internalType: 'struct InterpreterCallerV1ConstructionConfig',
+				name: 'config_',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'constructor'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'flowMinOutputs_',
+				type: 'uint256'
+			}
+		],
+		name: 'BadMinStackLength',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'i',
+				type: 'uint256'
+			}
+		],
+		name: 'InvalidSignature',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'expectedHash',
+				type: 'bytes32'
+			},
+			{
+				internalType: 'bytes32',
+				name: 'actualHash',
+				type: 'bytes32'
+			}
+		],
+		name: 'UnexpectedMetaHash',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'unregisteredHash',
+				type: 'bytes32'
+			}
+		],
+		name: 'UnregisteredFlow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC1155Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC20Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedERC721Flow',
+		type: 'error'
+	},
+	{
+		inputs: [],
+		name: 'UnsupportedNativeFlow',
+		type: 'error'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256[][]',
+				name: 'context',
+				type: 'uint256[][]'
+			}
+		],
+		name: 'Context',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				indexed: false,
+				internalType: 'struct Evaluable',
+				name: 'evaluable',
+				type: 'tuple'
+			}
+		],
+		name: 'FlowInitialized',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'contract IExpressionDeployerV1',
+						name: 'deployer',
+						type: 'address'
+					},
+					{
+						internalType: 'bytes[]',
+						name: 'sources',
+						type: 'bytes[]'
+					},
+					{
+						internalType: 'uint256[]',
+						name: 'constants',
+						type: 'uint256[]'
+					}
+				],
+				indexed: false,
+				internalType: 'struct EvaluableConfig[]',
+				name: 'config',
+				type: 'tuple[]'
+			}
+		],
+		name: 'Initialize',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'uint8',
+				name: 'version',
+				type: 'uint8'
+			}
+		],
+		name: 'Initialized',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'bytes',
+				name: 'callerMeta',
+				type: 'bytes'
+			}
+		],
+		name: 'InterpreterCallerMeta',
+		type: 'event'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				internalType: 'struct Evaluable',
+				name: 'evaluable_',
+				type: 'tuple'
+			},
+			{
+				internalType: 'uint256[]',
+				name: 'callerContext_',
+				type: 'uint256[]'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'signer',
+						type: 'address'
+					},
+					{
+						internalType: 'bytes',
+						name: 'signature',
+						type: 'bytes'
+					},
+					{
+						internalType: 'uint256[]',
+						name: 'context',
+						type: 'uint256[]'
+					}
+				],
+				internalType: 'struct SignedContext[]',
+				name: 'signedContexts_',
+				type: 'tuple[]'
+			}
+		],
+		name: 'flow',
+		outputs: [],
+		stateMutability: 'payable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes',
+				name: 'data_',
+				type: 'bytes'
+			}
+		],
+		name: 'initialize',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'data',
+				type: 'bytes[]'
+			}
+		],
+		name: 'multicall',
+		outputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'results',
+				type: 'bytes[]'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256[]',
+				name: '',
+				type: 'uint256[]'
+			},
+			{
+				internalType: 'uint256[]',
+				name: '',
+				type: 'uint256[]'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC1155BatchReceived',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC1155Received',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: '',
+				type: 'bytes'
+			}
+		],
+		name: 'onERC721Received',
+		outputs: [
+			{
+				internalType: 'bytes4',
+				name: '',
+				type: 'bytes4'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'contract IInterpreterV1',
+						name: 'interpreter',
+						type: 'address'
+					},
+					{
+						internalType: 'contract IInterpreterStoreV1',
+						name: 'store',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'expression',
+						type: 'address'
+					}
+				],
+				internalType: 'struct Evaluable',
+				name: 'evaluable_',
+				type: 'tuple'
+			},
+			{
+				internalType: 'uint256[]',
+				name: 'callerContext_',
+				type: 'uint256[]'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'signer',
+						type: 'address'
+					},
+					{
+						internalType: 'bytes',
+						name: 'signature',
+						type: 'bytes'
+					},
+					{
+						internalType: 'uint256[]',
+						name: 'context',
+						type: 'uint256[]'
+					}
+				],
+				internalType: 'struct SignedContext[]',
+				name: 'signedContexts_',
+				type: 'tuple[]'
+			}
+		],
+		name: 'previewFlow',
+		outputs: [
+			{
+				components: [
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'from',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'to',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'amount',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct NativeTransfer[]',
+						name: 'native',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'from',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'to',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'amount',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC20Transfer[]',
+						name: 'erc20',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'from',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'to',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'id',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC721Transfer[]',
+						name: 'erc721',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'from',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'to',
+								type: 'address'
+							},
+							{
+								internalType: 'uint256',
+								name: 'id',
+								type: 'uint256'
+							},
+							{
+								internalType: 'uint256',
+								name: 'amount',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct ERC1155Transfer[]',
+						name: 'erc1155',
+						type: 'tuple[]'
+					}
+				],
+				internalType: 'struct FlowTransfer',
+				name: '',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes4',
+				name: 'interfaceId',
+				type: 'bytes4'
+			}
+		],
+		name: 'supportsInterface',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		stateMutability: 'payable',
+		type: 'receive'
+	}
+];
+
+export const tupleFormat =
+	'tuple(tuple(address deployer, bytes[] sources, uint256[] constants) dummyConfig, tuple(address deployer, bytes[] sources, uint256[] constants)[] config)';
+
+const Flow: ImplementationDataFormat = {
+	abi,
+	initializeTuple: tupleFormat,
+	type: 'implementation'
+};
+
+export default Flow;

--- a/src/lib/abis/index.ts
+++ b/src/lib/abis/index.ts
@@ -1,0 +1,21 @@
+import clone from './clone-factory';
+import flow from './flow-factory';
+import flowERC20 from './flow-erc20-factory';
+import flowERC721 from './flow-erc721-factory';
+import orderbook from './orderbook';
+import type { ContractDataFormat, ImplementationDataFormat } from './types';
+
+export function getContractInfo(
+	slug_: string
+): ContractDataFormat | ImplementationDataFormat | null {
+	if (slug_ == 'orderbook') return orderbook;
+	if (slug_ == 'flow-factory') return flow;
+	if (slug_ == 'flow-erc20-factory') return flowERC20;
+	if (slug_ == 'flow-erc721-factory') return flowERC721;
+
+	return null;
+}
+
+export function getCloneFactory() {
+	return clone;
+}

--- a/src/lib/abis/orderbook/index.ts
+++ b/src/lib/abis/orderbook/index.ts
@@ -1,0 +1,1712 @@
+import type { ContractDataFormat } from '../types';
+
+export const abi = [
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'bytes',
+						name: 'callerMeta',
+						type: 'bytes'
+					},
+					{
+						internalType: 'address',
+						name: 'deployer',
+						type: 'address'
+					}
+				],
+				internalType: 'struct InterpreterCallerV1ConstructionConfig',
+				name: 'config_',
+				type: 'tuple'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'constructor'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'receiver',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'token',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'amount',
+				type: 'uint256'
+			}
+		],
+		name: 'ActiveDebt',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'result',
+				type: 'bytes32'
+			}
+		],
+		name: 'FlashLenderCallbackFailed',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'uint256',
+				name: 'minimumInput',
+				type: 'uint256'
+			},
+			{
+				internalType: 'uint256',
+				name: 'input',
+				type: 'uint256'
+			}
+		],
+		name: 'MinimumInput',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			}
+		],
+		name: 'NotOrderOwner',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			}
+		],
+		name: 'SameOwner',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'a',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'b',
+				type: 'address'
+			}
+		],
+		name: 'TokenMismatch',
+		type: 'error'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'expectedHash',
+				type: 'bytes32'
+			},
+			{
+				internalType: 'bytes32',
+				name: 'actualHash',
+				type: 'bytes32'
+			}
+		],
+		name: 'UnexpectedMetaHash',
+		type: 'error'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'contract IExpressionDeployerV1',
+				name: 'expressionDeployer',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'owner',
+						type: 'address'
+					},
+					{
+						internalType: 'bool',
+						name: 'handleIO',
+						type: 'bool'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IInterpreterV1',
+								name: 'interpreter',
+								type: 'address'
+							},
+							{
+								internalType: 'contract IInterpreterStoreV1',
+								name: 'store',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'expression',
+								type: 'address'
+							}
+						],
+						internalType: 'struct Evaluable',
+						name: 'evaluable',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				indexed: false,
+				internalType: 'struct Order',
+				name: 'order',
+				type: 'tuple'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'orderHash',
+				type: 'uint256'
+			}
+		],
+		name: 'AddOrder',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'uint256',
+						name: 'aOutput',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bOutput',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'aInput',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bInput',
+						type: 'uint256'
+					}
+				],
+				indexed: false,
+				internalType: 'struct ClearStateChange',
+				name: 'clearStateChange',
+				type: 'tuple'
+			}
+		],
+		name: 'AfterClear',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'owner',
+						type: 'address'
+					},
+					{
+						internalType: 'bool',
+						name: 'handleIO',
+						type: 'bool'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IInterpreterV1',
+								name: 'interpreter',
+								type: 'address'
+							},
+							{
+								internalType: 'contract IInterpreterStoreV1',
+								name: 'store',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'expression',
+								type: 'address'
+							}
+						],
+						internalType: 'struct Evaluable',
+						name: 'evaluable',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				indexed: false,
+				internalType: 'struct Order',
+				name: 'a',
+				type: 'tuple'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'owner',
+						type: 'address'
+					},
+					{
+						internalType: 'bool',
+						name: 'handleIO',
+						type: 'bool'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IInterpreterV1',
+								name: 'interpreter',
+								type: 'address'
+							},
+							{
+								internalType: 'contract IInterpreterStoreV1',
+								name: 'store',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'expression',
+								type: 'address'
+							}
+						],
+						internalType: 'struct Evaluable',
+						name: 'evaluable',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				indexed: false,
+				internalType: 'struct Order',
+				name: 'b',
+				type: 'tuple'
+			},
+			{
+				components: [
+					{
+						internalType: 'uint256',
+						name: 'aInputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'aOutputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bInputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bOutputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'aBountyVaultId',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bBountyVaultId',
+						type: 'uint256'
+					}
+				],
+				indexed: false,
+				internalType: 'struct ClearConfig',
+				name: 'clearConfig',
+				type: 'tuple'
+			}
+		],
+		name: 'Clear',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256[][]',
+				name: 'context',
+				type: 'uint256[][]'
+			}
+		],
+		name: 'Context',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'token',
+						type: 'address'
+					},
+					{
+						internalType: 'uint256',
+						name: 'vaultId',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'amount',
+						type: 'uint256'
+					}
+				],
+				indexed: false,
+				internalType: 'struct DepositConfig',
+				name: 'config',
+				type: 'tuple'
+			}
+		],
+		name: 'Deposit',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'uint8',
+				name: 'version',
+				type: 'uint8'
+			}
+		],
+		name: 'Initialized',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'bytes',
+				name: 'callerMeta',
+				type: 'bytes'
+			}
+		],
+		name: 'InterpreterCallerMeta',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'orderHash',
+				type: 'uint256'
+			}
+		],
+		name: 'OrderExceedsMaxRatio',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'orderHash',
+				type: 'uint256'
+			}
+		],
+		name: 'OrderNotFound',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'orderHash',
+				type: 'uint256'
+			}
+		],
+		name: 'OrderZeroAmount',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'owner',
+						type: 'address'
+					},
+					{
+						internalType: 'bool',
+						name: 'handleIO',
+						type: 'bool'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IInterpreterV1',
+								name: 'interpreter',
+								type: 'address'
+							},
+							{
+								internalType: 'contract IInterpreterStoreV1',
+								name: 'store',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'expression',
+								type: 'address'
+							}
+						],
+						internalType: 'struct Evaluable',
+						name: 'evaluable',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				indexed: false,
+				internalType: 'struct Order',
+				name: 'order',
+				type: 'tuple'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'orderHash',
+				type: 'uint256'
+			}
+		],
+		name: 'RemoveOrder',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'owner',
+								type: 'address'
+							},
+							{
+								internalType: 'bool',
+								name: 'handleIO',
+								type: 'bool'
+							},
+							{
+								components: [
+									{
+										internalType: 'contract IInterpreterV1',
+										name: 'interpreter',
+										type: 'address'
+									},
+									{
+										internalType: 'contract IInterpreterStoreV1',
+										name: 'store',
+										type: 'address'
+									},
+									{
+										internalType: 'address',
+										name: 'expression',
+										type: 'address'
+									}
+								],
+								internalType: 'struct Evaluable',
+								name: 'evaluable',
+								type: 'tuple'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'uint8',
+										name: 'decimals',
+										type: 'uint8'
+									},
+									{
+										internalType: 'uint256',
+										name: 'vaultId',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct IO[]',
+								name: 'validInputs',
+								type: 'tuple[]'
+							},
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'token',
+										type: 'address'
+									},
+									{
+										internalType: 'uint8',
+										name: 'decimals',
+										type: 'uint8'
+									},
+									{
+										internalType: 'uint256',
+										name: 'vaultId',
+										type: 'uint256'
+									}
+								],
+								internalType: 'struct IO[]',
+								name: 'validOutputs',
+								type: 'tuple[]'
+							},
+							{
+								internalType: 'bytes',
+								name: 'data',
+								type: 'bytes'
+							}
+						],
+						internalType: 'struct Order',
+						name: 'order',
+						type: 'tuple'
+					},
+					{
+						internalType: 'uint256',
+						name: 'inputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'outputIOIndex',
+						type: 'uint256'
+					}
+				],
+				indexed: false,
+				internalType: 'struct TakeOrderConfig',
+				name: 'config',
+				type: 'tuple'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'input',
+				type: 'uint256'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'output',
+				type: 'uint256'
+			}
+		],
+		name: 'TakeOrder',
+		type: 'event'
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'sender',
+				type: 'address'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'token',
+						type: 'address'
+					},
+					{
+						internalType: 'uint256',
+						name: 'vaultId',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'amount',
+						type: 'uint256'
+					}
+				],
+				indexed: false,
+				internalType: 'struct WithdrawConfig',
+				name: 'config',
+				type: 'tuple'
+			},
+			{
+				indexed: false,
+				internalType: 'uint256',
+				name: 'amount',
+				type: 'uint256'
+			}
+		],
+		name: 'Withdraw',
+		type: 'event'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IExpressionDeployerV1',
+								name: 'deployer',
+								type: 'address'
+							},
+							{
+								internalType: 'bytes[]',
+								name: 'sources',
+								type: 'bytes[]'
+							},
+							{
+								internalType: 'uint256[]',
+								name: 'constants',
+								type: 'uint256[]'
+							}
+						],
+						internalType: 'struct EvaluableConfig',
+						name: 'evaluableConfig',
+						type: 'tuple'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				internalType: 'struct OrderConfig',
+				name: 'config_',
+				type: 'tuple'
+			}
+		],
+		name: 'addOrder',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'owner',
+						type: 'address'
+					},
+					{
+						internalType: 'bool',
+						name: 'handleIO',
+						type: 'bool'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IInterpreterV1',
+								name: 'interpreter',
+								type: 'address'
+							},
+							{
+								internalType: 'contract IInterpreterStoreV1',
+								name: 'store',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'expression',
+								type: 'address'
+							}
+						],
+						internalType: 'struct Evaluable',
+						name: 'evaluable',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				internalType: 'struct Order',
+				name: 'a_',
+				type: 'tuple'
+			},
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'owner',
+						type: 'address'
+					},
+					{
+						internalType: 'bool',
+						name: 'handleIO',
+						type: 'bool'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IInterpreterV1',
+								name: 'interpreter',
+								type: 'address'
+							},
+							{
+								internalType: 'contract IInterpreterStoreV1',
+								name: 'store',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'expression',
+								type: 'address'
+							}
+						],
+						internalType: 'struct Evaluable',
+						name: 'evaluable',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				internalType: 'struct Order',
+				name: 'b_',
+				type: 'tuple'
+			},
+			{
+				components: [
+					{
+						internalType: 'uint256',
+						name: 'aInputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'aOutputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bInputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bOutputIOIndex',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'aBountyVaultId',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'bBountyVaultId',
+						type: 'uint256'
+					}
+				],
+				internalType: 'struct ClearConfig',
+				name: 'clearConfig_',
+				type: 'tuple'
+			}
+		],
+		name: 'clear',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'token',
+						type: 'address'
+					},
+					{
+						internalType: 'uint256',
+						name: 'vaultId',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'amount',
+						type: 'uint256'
+					}
+				],
+				internalType: 'struct DepositConfig',
+				name: 'config_',
+				type: 'tuple'
+			}
+		],
+		name: 'deposit',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		name: 'flashFee',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'pure',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'contract IERC3156FlashBorrower',
+				name: 'receiver_',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: 'token_',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: 'amount_',
+				type: 'uint256'
+			},
+			{
+				internalType: 'bytes',
+				name: 'data_',
+				type: 'bytes'
+			}
+		],
+		name: 'flashLoan',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'token_',
+				type: 'address'
+			}
+		],
+		name: 'maxFlashLoan',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'data',
+				type: 'bytes[]'
+			}
+		],
+		name: 'multicall',
+		outputs: [
+			{
+				internalType: 'bytes[]',
+				name: 'results',
+				type: 'bytes[]'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'owner',
+						type: 'address'
+					},
+					{
+						internalType: 'bool',
+						name: 'handleIO',
+						type: 'bool'
+					},
+					{
+						components: [
+							{
+								internalType: 'contract IInterpreterV1',
+								name: 'interpreter',
+								type: 'address'
+							},
+							{
+								internalType: 'contract IInterpreterStoreV1',
+								name: 'store',
+								type: 'address'
+							},
+							{
+								internalType: 'address',
+								name: 'expression',
+								type: 'address'
+							}
+						],
+						internalType: 'struct Evaluable',
+						name: 'evaluable',
+						type: 'tuple'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validInputs',
+						type: 'tuple[]'
+					},
+					{
+						components: [
+							{
+								internalType: 'address',
+								name: 'token',
+								type: 'address'
+							},
+							{
+								internalType: 'uint8',
+								name: 'decimals',
+								type: 'uint8'
+							},
+							{
+								internalType: 'uint256',
+								name: 'vaultId',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct IO[]',
+						name: 'validOutputs',
+						type: 'tuple[]'
+					},
+					{
+						internalType: 'bytes',
+						name: 'data',
+						type: 'bytes'
+					}
+				],
+				internalType: 'struct Order',
+				name: 'order_',
+				type: 'tuple'
+			}
+		],
+		name: 'removeOrder',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'output',
+						type: 'address'
+					},
+					{
+						internalType: 'address',
+						name: 'input',
+						type: 'address'
+					},
+					{
+						internalType: 'uint256',
+						name: 'minimumInput',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'maximumInput',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'maximumIORatio',
+						type: 'uint256'
+					},
+					{
+						components: [
+							{
+								components: [
+									{
+										internalType: 'address',
+										name: 'owner',
+										type: 'address'
+									},
+									{
+										internalType: 'bool',
+										name: 'handleIO',
+										type: 'bool'
+									},
+									{
+										components: [
+											{
+												internalType: 'contract IInterpreterV1',
+												name: 'interpreter',
+												type: 'address'
+											},
+											{
+												internalType: 'contract IInterpreterStoreV1',
+												name: 'store',
+												type: 'address'
+											},
+											{
+												internalType: 'address',
+												name: 'expression',
+												type: 'address'
+											}
+										],
+										internalType: 'struct Evaluable',
+										name: 'evaluable',
+										type: 'tuple'
+									},
+									{
+										components: [
+											{
+												internalType: 'address',
+												name: 'token',
+												type: 'address'
+											},
+											{
+												internalType: 'uint8',
+												name: 'decimals',
+												type: 'uint8'
+											},
+											{
+												internalType: 'uint256',
+												name: 'vaultId',
+												type: 'uint256'
+											}
+										],
+										internalType: 'struct IO[]',
+										name: 'validInputs',
+										type: 'tuple[]'
+									},
+									{
+										components: [
+											{
+												internalType: 'address',
+												name: 'token',
+												type: 'address'
+											},
+											{
+												internalType: 'uint8',
+												name: 'decimals',
+												type: 'uint8'
+											},
+											{
+												internalType: 'uint256',
+												name: 'vaultId',
+												type: 'uint256'
+											}
+										],
+										internalType: 'struct IO[]',
+										name: 'validOutputs',
+										type: 'tuple[]'
+									},
+									{
+										internalType: 'bytes',
+										name: 'data',
+										type: 'bytes'
+									}
+								],
+								internalType: 'struct Order',
+								name: 'order',
+								type: 'tuple'
+							},
+							{
+								internalType: 'uint256',
+								name: 'inputIOIndex',
+								type: 'uint256'
+							},
+							{
+								internalType: 'uint256',
+								name: 'outputIOIndex',
+								type: 'uint256'
+							}
+						],
+						internalType: 'struct TakeOrderConfig[]',
+						name: 'orders',
+						type: 'tuple[]'
+					}
+				],
+				internalType: 'struct TakeOrdersConfig',
+				name: 'takeOrders_',
+				type: 'tuple'
+			}
+		],
+		name: 'takeOrders',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: 'totalInput_',
+				type: 'uint256'
+			},
+			{
+				internalType: 'uint256',
+				name: 'totalOutput_',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address'
+			},
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		name: 'vaultBalance',
+		outputs: [
+			{
+				internalType: 'uint256',
+				name: '',
+				type: 'uint256'
+			}
+		],
+		stateMutability: 'view',
+		type: 'function'
+	},
+	{
+		inputs: [
+			{
+				components: [
+					{
+						internalType: 'address',
+						name: 'token',
+						type: 'address'
+					},
+					{
+						internalType: 'uint256',
+						name: 'vaultId',
+						type: 'uint256'
+					},
+					{
+						internalType: 'uint256',
+						name: 'amount',
+						type: 'uint256'
+					}
+				],
+				internalType: 'struct WithdrawConfig',
+				name: 'config_',
+				type: 'tuple'
+			}
+		],
+		name: 'withdraw',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function'
+	}
+];
+
+const Orderbook: ContractDataFormat = {
+	abi,
+	type: 'contract'
+};
+
+export default Orderbook;

--- a/src/lib/abis/types.ts
+++ b/src/lib/abis/types.ts
@@ -1,0 +1,13 @@
+type DataFormat = {
+	abi: any[];
+	type: 'contract' | 'implementation';
+};
+
+export type ContractDataFormat = DataFormat & {
+	type: 'contract';
+};
+
+export type ImplementationDataFormat = DataFormat & {
+	type: 'implementation';
+	initializeTuple: string;
+};

--- a/src/lib/utils/meta.ts
+++ b/src/lib/utils/meta.ts
@@ -33,6 +33,9 @@ export function formatContract(contracts_: SGContract[]): FormattedContract[] {
 
 	for (let i = 0; i < contracts_.length; i++) {
 		const contract = contracts_[i];
+
+		if (!contract.opmeta) continue;
+		
 		const meta = parseMeta(contract.opmeta);
 
 		if (_contracts[meta.alias]) {

--- a/src/routes/contracts/[slug]/+page.server.ts
+++ b/src/routes/contracts/[slug]/+page.server.ts
@@ -159,7 +159,6 @@ export const load: PageServerLoad = async (event) => {
 
 	const interpreterDeployers = dataSg.expressionDeployers;
 
-	slugData;
 
 	return {
 		contract: contractQuery?.data,

--- a/src/routes/contracts/[slug]/+page.svelte
+++ b/src/routes/contracts/[slug]/+page.svelte
@@ -3,8 +3,12 @@
 	import PageHeader from '$lib/PageHeader.svelte';
 	import ProjectTag from '$lib/ProjectTag.svelte';
 	import { logoUrlRain, nameRain } from '$lib/utils/constants';
-	import { Tab, TabList, Tabs } from 'rain-svelte-components/package/tabs/tabs';
+	import { getCloneFactory, getContractInfo } from '$lib/abis';
+	import { Tab, TabList, TabPanel, Tabs } from 'rain-svelte-components/package/tabs/tabs';
 	import Sidebar from './Sidebar.svelte';
+	import Summary from './Summary.svelte';
+	import { Ring } from 'rain-svelte-components/package';
+	import Write from './Write.svelte';
 
 	$: contract = $page.data.contract;
 	$: knowContracts = $page.data.knowContracts;
@@ -12,8 +16,11 @@
 	$: meta = $page.data.meta;
 
 	$: project = contract?.project;
-	// $: metadata = contract?.metadata;
-	// $: abi = contract?.abi;
+	$: metadata = {
+		description: meta.desc,
+		addresses: slugData.knownAddress
+	};
+	$: contractF = getContractInfo($page.params.slug);
 
 	$: addressCount = slugData?.knownAddress.length;
 </script>
@@ -31,26 +38,28 @@
 		</div>
 	</div>
 </PageHeader>
-<Tabs>
-	<div class="w-full bg-gray-100">
-		<div class="container mx-auto px-4 sm:px-0 ">
-			<TabList>
-				<Tab>Contract</Tab>
-				<Tab>Write</Tab>
-				<Tab>Examples</Tab>
-				<Tab>Community</Tab>
-			</TabList>
+{#if contractF}
+	<Tabs>
+		<div class="w-full bg-gray-100">
+			<div class="container mx-auto px-4 sm:px-0 ">
+				<TabList>
+					<Tab>Contract</Tab>
+					<Tab>Write</Tab>
+					<Tab>Examples</Tab>
+					<Tab>Community</Tab>
+				</TabList>
+			</div>
 		</div>
-	</div>
-	<div class="justify-stretch container mx-auto flex flex-col gap-y-8 px-4 sm:px-0 lg:flex-row">
-		<div class="flex flex-col gap-y-8 pt-10 lg:w-2/3 lg:pr-6">
-			<!-- <TabPanel>
-				<Summary {abi} {metadata} />
-			</TabPanel> -->
-			<!-- <TabPanel>
-				<Write {abi} {metadata} {contract} />
-			</TabPanel> -->
+		<div class="justify-stretch container mx-auto flex flex-col gap-y-8 px-4 sm:px-0 lg:flex-row">
+			<div class="flex flex-col gap-y-8 pt-10 lg:w-2/3 lg:pr-6">
+				<TabPanel>
+					<Summary {metadata} />
+				</TabPanel>
+				<!-- <TabPanel>
+					<Write abi={contractF.abi} {metadata} {contract} />
+				</TabPanel> -->
+			</div>
+			<div class="py-8 lg:w-1/3"><Sidebar {contract} /></div>
 		</div>
-		<div class="py-8 lg:w-1/3"><Sidebar {contract} /></div>
-	</div>
-</Tabs>
+	</Tabs>
+{/if}

--- a/src/routes/contracts/[slug]/Summary.svelte
+++ b/src/routes/contracts/[slug]/Summary.svelte
@@ -2,10 +2,10 @@
 	import { Section, SectionBody, SectionHeading } from 'rain-svelte-components/package/section';
 	import type { ContractMetadata } from 'rain-metadata/metadata-types/contract';
 	import { allChainsData } from 'svelte-ethers-store';
-	export let abi: any, metadata: ContractMetadata;
+	export let metadata: any;
 </script>
 
-<div>
+<div class="whitespace-pre-line">
 	{metadata.description}
 </div>
 <Section>
@@ -19,16 +19,13 @@
 					<td class="pb-2">Address</td>
 				</tr>
 				{#if metadata.addresses}
-					{#each metadata.addresses as chain}
-						{#each chain.knownAddresses as knownAddress}
-							<tr>
-								<td class="pt-3"
-									>{allChainsData.find((_chain) => _chain.chainId == chain.chainId)?.name}</td
-								>
-								<td class="pt-3">{chain.chainId}</td>
-								<td class="block w-48 truncate pt-3 md:w-full">{knownAddress}</td>
-							</tr>
-						{/each}
+					{#each metadata.addresses as knownAddress}
+						<tr>
+							<!-- TODO: REMOVE HARDCODED -->
+							<td class="pt-3">Mumbai</td>
+							<td class="pt-3">80001</td>
+							<td class="block w-48 truncate pt-3 md:w-full">{knownAddress}</td>
+						</tr>
 					{/each}
 				{/if}
 			</table>


### PR DESCRIPTION
This PR start removing the functionality to get ABI and metada from supabase which aim to get them by another source.

Hopefully, this data will be getting from the contract meta, but meanwhile there are some class definitions that contain the ABI and the tuple initialization of some contracts